### PR TITLE
Fix/docker compose network

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@
 **Ogmios** is a translation service written in Haskell running on top of [cardano-node](https://github.com/input-output-hk/cardano-node/). It offers a [JSON-WSP](https://en.wikipedia.org/wiki/JSON-WSP) interface through WebSockets and enables clients to speak [Ouroboros' mini-protocols](https://hydra.iohk.io/build/1070091/download/1/network.pdf#chapter.3) via remote procedure calls over JSON.
 
 ```
-            CARDANO RELAY                                     OGMIOS SERVER   
-                                                                           
-                  ◦                                                _=_       
-<-------->    ◦   ○   ◦                                          q(-_-)p     
-               ○ ◯ ◯ ○                                            _\=/_      
+            CARDANO RELAY                                     OGMIOS SERVER
+
+                  ◦                                                _=_
+<-------->    ◦   ○   ◦                                          q(-_-)p
+               ○ ◯ ◯ ○                                            _\=/_
 <--------> ◦ ○ ◯     ◯ ○ ◦  <----Mini-Protocols / CBOR---->      /     \     <----WebSocket / JSON---->
-               ○ ◯ ◯ ○                                         _(<\   />)_   
-<-------->    ◦   ○   ◦                                       (__\_\_/_/__)  
+               ○ ◯ ◯ ○                                         _(<\   />)_
+<-------->    ◦   ○   ◦                                       (__\_\_/_/__)
                   ◦
 ```
 
@@ -30,16 +30,16 @@ Ouroboros' mini-protocols are described as state-machines. **Ogmios** currently 
 ```
  *-----------*                                              | Clients wishing to synchronise blocks from
  | Intersect |◀══════════════════════════════╗              | the chain can use the Chain Sync protocol.
- *-----------*         FindIntersect         ║              | 
+ *-----------*         FindIntersect         ║              |
        │                                     ║              | The protocol is stateful, which means that
        │                                *---------*         | each connection between clients and ogmios
        │ Intersect.{Found,NotFound}     |         |         | has a state: a  cursor locating a point on
        └───────────────────────────────╼|         |         | the chain.
-                                        |   Idle  |         | 
+                                        |   Idle  |         |
     ╔═══════════════════════════════════|         |         | Typically, a client will  start by looking
     ║            RequestNext            |         |⇦ START  | for an intersection  between its own local
     ║                                   *---------*         | chain and  the one from the  node / ogmios.
-    ▼                                        ╿              |  
+    ▼                                        ╿              |
  *------*       Roll.{Backward,Forward}      │              | Then, it'll simply request the next action
  | Next |────────────────────────────────────┘              | to take: either rolling forward and adding
  *------*                                                   | new blocks, or rolling backward.
@@ -52,13 +52,13 @@ Ouroboros' mini-protocols are described as state-machines. **Ogmios** currently 
 
 ```
  *----------*                                                | Transaction submission is pretty simple &
- |   Busy   |◀══════════════════════════════╗                | works by submitting an already serialized 
+ |   Busy   |◀══════════════════════════════╗                | works by submitting an already serialized
  *----------*            SubmitTx           ║                | and signed UTxO transaction as one single
-      │                                     ║                | message. 
-      │                                *---------*           | 
+      │                                     ║                | message.
+      │                                *---------*           |
       │                                |         |           | In case of  success, the server returns an
       │                                |         |           | empty  response. Otherwise, it  returns an
-      │          SubmitTxResponse      |   Idle  |           | error  with some details  about what  went 
+      │          SubmitTxResponse      |   Idle  |           | error  with some details  about what  went
       └───────────────────────────────╼|         |           | wrong.
                                        |         |⇦ START    |
                                        *---------*           | Clients must thereby know how to construct
@@ -68,8 +68,8 @@ Ouroboros' mini-protocols are described as state-machines. **Ogmios** currently 
 
 ### Why Bother?
 
-Ogmios brings the Ouroboros mini-protocols to the Web, effectively allowing light clients to interact with 
-a relay node in a very simple and efficient way. Ogmios is very lightweight too and can be deployed alongside 
+Ogmios brings the Ouroboros mini-protocols to the Web, effectively allowing light clients to interact with
+a relay node in a very simple and efficient way. Ogmios is very lightweight too and can be deployed alongside
 relays to create entry points on the Cardano network for various type of applications (e.g. wallets, explorers,
 chatbots, dashboards...).
 
@@ -89,19 +89,25 @@ to display, in-real-time, the current tip of MainNet.
 - An OBFT Byron cardano-node, connected to `MainNet`.
 - An Ogmios server, listening to `localhost` on port `:1337`.
 
+## testnet
+
+```
+NETWORK=testnet OGMIOS_PORT=1338 docker-compose -p cardano-ogmios-testnet up
+```
+
 Check out the [demo source](https://github.com/KtorZ/cardano-ogmios/blob/master/demo/demo.js) for a detailed albeit simple client example!
 
 <hr/>
 
 <p align="center">
-  <a href="https://ktorz.github.io/cardano-ogmios/api-reference">:book: API Reference</a> 
+  <a href="https://ktorz.github.io/cardano-ogmios/api-reference">:book: API Reference</a>
   |
   <a href="docs/COMMAND_LINE.md">:computer: Command-Line Interface</a>
   |
   <a href="docs/AWS_DEPLOYMENT.md">:package: Deployment Guide</a>
   |
   <a href="CONTRIBUTING.md">:gift: Contributing</a>
-  | 
+  |
   <a href="CHANGELOG.md">:floppy_disk: Changelog</a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ to display, in-real-time, the current tip of MainNet.
 :point_up: This will run and connect together:
 
 - An OBFT Byron cardano-node, connected to `MainNet`.
-- An Ogmios server, listening to `localhost` on port `:1337`.
+- An Ogmios server using the `latest` Dockerhub build, listening to `localhost` on port `:1337`.
+- To build Ogmios from source, pass the `--build` flag
 
 ## testnet
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,9 @@ services:
     image: inputoutput/cardano-node:1.20.0
     restart: on-failure
     environment:
-      NETWORK:
+      - NETWORK=${NETWORK:-mainnet}
     volumes:
-      - node-${NETWORK}-db:/data
+      - node-db:/data
       - node-ipc:/ipc
     logging:
       driver: "json-file"
@@ -19,14 +19,13 @@ services:
     image: ktorz/ogmios:latest
     restart: on-failure
     environment:
-      - OGMIOS_NETWORK=${NETWORK}
+      - OGMIOS_NETWORK=${NETWORK:-mainnet}
     command: ["--host", "0.0.0.0", "--node-socket", "/ipc/node.socket"]
     volumes:
       - node-ipc:/ipc
     ports:
-      - 1337:1337
+      - ${OGMIOS_PORT:-1337}:1337
 
 volumes:
-  node-mainnet-db:
-  node-testnet-db:
+  node-db:
   node-ipc:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,10 @@ services:
       - node-${NETWORK}-db:/data
       - node-ipc:/ipc
     logging:
-      driver: none
+      driver: "json-file"
+      options:
+        max-size: "400k"
+        max-file: "20"
 
   ogmios:
     image: ktorz/ogmios:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
         max-file: "20"
 
   ogmios:
+    build: .
     image: ktorz/ogmios:latest
     restart: on-failure
     environment:


### PR DESCRIPTION
- add ENV to select `cardano-node` config
- default to _mainnet_
- use _projects_ to naturally handle data volume grouping
- make Ogmios port configurable
- enable logging for `cardano-node` container
- add build info to README, and fix codestyle violations

