### PR TITLE
Enable compact-mode

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -4,7 +4,7 @@ title = "Overview"
 
 ## Overview
 
-[**Ogmios**](https://github.com/KtorZ/cardano-ogmios) is a protocol translation service written in Haskell running on top of [cardano-node](https://github.com/input-output-hk/cardano-node/). It offers a [JSON-WSP](https://en.wikipedia.org/wiki/JSON-WSP) interface through WebSockets and enables applications to speak [Ouroboros' mini-protocols](https://hydra.iohk.io/build/1070091/download/1/network.pdf#chapter.3) via remote procedure calls over JSON. Ogmios is very lightweight too and can be deployed alongside relays to create entry points on the Cardano network for various types of applications (e.g. wallets, explorers, chatbots, dashboards...).
+[**Ogmios**](https://github.com/KtorZ/cardano-ogmios) is a protocol translation service written in Haskell running on top of [cardano-node](https://github.com/input-output-hk/cardano-node/). It offers a [JSON-WSP](https://en.wikipedia.org/wiki/JSON-WSP) interface through WebSockets and enables applications to speak [Ouroboros' client mini-protocols](https://hydra.iohk.io/build/1070091/download/1/network.pdf#chapter.3) via remote procedure calls over JSON. Ogmios is very lightweight too and can be deployed alongside relays to create entry points on the Cardano network for various types of applications (e.g. wallets, explorers, chatbots, dashboards...).
 
 ## Motivation
 
@@ -13,7 +13,3 @@ All programs offer more or less elaborated interfaces for either user or program
 In order to interact with a Cardano node, one must therefore speak one of these so-called _Ouroboros mini-protocols_. This is an impediment to mass adoption for the only existing implementation of those protocols is written in _Haskell_ (and therefore, only available to Haskell applications). Ogmios is an attempt to lower down that entry barrier by translating the interface with a set of technologies that is well-known on the Web. In essence, it is very much like putting a power socket adaptor on the wall in order to branch a device with a peculiar plug; Cardano node is the device, Ogmios is the socket adaptor. 
 
 Ogmios is very lightweight and doesn't do much on its own. It is running next to a Cardano node and it acts as an intermediary for other client applications. Ogmios emulates the Ouroboros mini-protocols through WebSockets and translates the binary on-chain data from and to JSON; both WebSockets and JSON are widespread over the Web and in many other applications so much that they offer the ideal mainstream interface that I hope will help getting more and more application developers to build with Cardano!
-
-## About me
-
-My name is Matthias (a.k.a [KtorZ](https://github.com/KtorZ)) and I currently work with the engineering teams of IOHK to build Cardano. My main area of focus within the Cardano project is basically anything that deals with a Cardano node, which means a lot of things! From a very young age, I've been enjoying designing and writing programs. Ogmios is yet another instance of this which I started as a proof-of-concept on my free-time, and which rapidly became one of my most sophisticated side-project. 

--- a/docs/content/api-reference/_index.md
+++ b/docs/content/api-reference/_index.md
@@ -6,7 +6,7 @@ chapter = false
 pre = "<b>4. </b>"
 +++
 
-Ogmios as a JSON-WSP service is entirely described using [JSON Schema - Draft 4](https://json-schema.org/). This can be fed into various tools to generate code, data-types or definitions in many languages. Ogmios is tested against this schema as well, to make sure that it remains up-to-date as new features are added. 
+Ogmios as a JSON-WSP service is entirely described using [JSON Schema - Draft 7](https://json-schema.org/). This can be fed into various tools to generate code, data-types or definitions in many languages. Ogmios is tested against this schema as well, to make sure that it remains up-to-date as new features are added.
 
 <p align="right">
   {{% button href="/api-reference.html" icon="fas fa-eye" %}}Explore JSON Schema{{% /button %}}

--- a/docs/content/mini-protocols/local-chain-sync.md
+++ b/docs/content/mini-protocols/local-chain-sync.md
@@ -206,3 +206,13 @@ A few important takes from this excerpt:
 {{% notice info %}}
 Note that Ogmios will do its best to pipeline requests to the Cardano node. Nevertheless, unlike WebSocket the local chain-sync protocol only allows for finite pipelining. Said differently, Ogmios cannot pipeline an arbitrary and potentially infinite number of requests and will actually starts collecting responses if too many requests are pipelined. So, if you're pipelining many requests in a client application, make sure to also take times to collect some responses because there will be no extra benefits coming from _too much pipelining_.
 {{% /notice %}}
+
+## Compact Serialization
+
+Since version `v3.2.0`, Ogmios supports a WebSocket sub-protocol which has an influence on the representation of some data objects. When set, this so-called _compact mode_ will omit proofs, signatures and other voluminous pieces of information from responses that are somewhat superfluous in a trustworthy setup (where for instance, your application fully trusts its node / Ogmios). As a consequence, responses are twice smaller, less bloated and the overall chain-sync synchronization is sped up by about 20%. To enable the compact serialization, use:
+
+```
+ogmios.compact.v1
+```
+
+as a sub-protocol when establishing the WebSocket connection. Omitted fields are documented in the [API reference](../../api-reference) using the `$omitted-if-compact` field of relevant objects.

--- a/docs/static/ogmios.wsp.json
+++ b/docs/static/ogmios.wsp.json
@@ -1,6 +1,6 @@
 { "type": "object"
 , "title": "ogmios"
-, "$schema": "http://json-schema.org/draft-04/schema#"
+, "$schema": "https://json-schema.org/draft-07/schema"
 
 , "properties":
 
@@ -989,30 +989,33 @@
     }
 
   , "Block":
-    { "type": "object"
-    , "oneOf":
-      [ { "required": [ "byron" ]
+    { "oneOf":
+      [ { "type": "object"
+        , "required": [ "byron" ]
         , "title": "byron"
         , "additionalProperties": false
         , "properties":
           { "byron": { "$ref": "#/definitions/Block[Byron]" }
           }
         }
-      , { "required": [ "shelley" ]
+      , { "type": "object"
+        , "required": [ "shelley" ]
         , "title": "shelley"
         , "additionalProperties": false
         , "properties":
           { "shelley": { "$ref": "#/definitions/Block[Shelley]" }
           }
         }
-      , { "required": [ "allegra" ]
+      , { "type": "object"
+        , "required": [ "allegra" ]
         , "title": "allegra"
         , "additionalProperties": false
         , "properties":
           { "allegra": { "$ref": "#/definitions/Block[Allegra]" }
           }
         }
-      , { "required": [ "mary" ]
+      , { "type": "object"
+        , "required": [ "mary" ]
         , "title": "mary"
         , "additionalProperties": false
         , "properties":
@@ -1079,6 +1082,7 @@
             { "type": "object"
             , "additionalProperties": false
             , "required": [ "blockHeight", "genesisKey", "prevHash", "proof", "protocolMagicId", "protocolVersion", "signature", "slot", "softwareVersion" ]
+            , "$omitted-if-compact": ["proof", "signature"]
             , "properties":
               { "blockHeight": { "$ref": "#/definitions/BlockNo" }
               , "genesisKey": { "$ref": "#/definitions/Hash16" }
@@ -1095,6 +1099,7 @@
             { "type": "object"
             , "additionalProperties": false
             , "required": [ "txPayload", "dlgPayload", "updatePayload" ]
+            , "$omitted-if-compact": ["dlgPayload"]
             , "properties":
               { "txPayload":
                 { "type": "array"
@@ -1102,6 +1107,7 @@
                   { "type": "object"
                   , "additionalProperties": false
                   , "required": [ "id", "body", "witness" ]
+                  , "$omitted-if-compact": ["witness"]
                   , "properties":
                     { "id": { "$ref": "#/definitions/Hash16" }
                     , "body": { "$ref": "#/definitions/Tx" }
@@ -1120,6 +1126,7 @@
                 { "type": "object"
                 , "additionalProperties": false
                 , "required": [ "proposal", "votes" ]
+                , "$omitted-if-compact": ["votes"]
                 , "properties":
                   { "proposal":
                     { "oneOf":
@@ -1266,6 +1273,7 @@
           { "type": "object"
           , "additionalProperties": false
           , "required": [ "id", "body", "witness", "metadata" ]
+          , "$omitted-if-compact": ["witness"]
           , "properties":
             { "id": { "$ref": "#/definitions/Hash16" }
             , "body":
@@ -1367,6 +1375,7 @@
           [ "blockHeight","slot","prevHash","issuerVk","issuerVrf","leaderValue"
           , "blockSize", "blockHash","opCert","protocolVersion","signature"
           ]
+        , "$omitted-if-compact": ["signature", "nonce", "leaderValue", "opCert", "protocolVersion"]
         , "properties":
           { "blockHeight": { "$ref": "#/definitions/BlockNo" }
           , "slot": { "$ref": "#/definitions/Slot" }
@@ -1472,6 +1481,7 @@
           { "type": "object"
           , "additionalProperties": false
           , "required": [ "id", "body", "witness", "metadata" ]
+          , "$omitted-if-compact": ["witness"]
           , "properties":
             { "id": { "$ref": "#/definitions/Hash16" }
             , "body":
@@ -1677,6 +1687,7 @@
           { "type": "object"
           , "additionalProperties": false
           , "required": [ "id", "body", "witness", "metadata" ]
+          , "$omitted-if-compact": ["witness"]
           , "properties":
             { "id": { "$ref": "#/definitions/Hash16" }
             , "body":

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -5,6 +5,25 @@ chapter: false
 pre: "<b>5. </b>"
 ---
 
+### [3.2.0] - unreleased
+
+#### Added
+
+- Support for WebSocket sub-protocols, with currently one support sub-protocol: `ogmios.compact.v1`. When enabled,
+  Ogmios will omit fields such as witnesses, proofs and signatures from responses to make responses smaller.
+- JSON-WSP faults are now documented in the JSON schema
+- Continuous integration job checking for code style and lint on the server source code.
+
+#### Changed
+
+- Rework Docker setup to not require an external snapshot image. Everything is now built in a single
+  `Dockerfile`, but cache from DockerHub can be leveraged to reduce overall build time when building
+  from scratch.
+
+#### Removed
+
+ø
+
 ### [3.1.0] - 2021-04-04
 
 #### Added

--- a/server/src/Ogmios/App/Server/WebSocket.hs
+++ b/server/src/Ogmios/App/Server/WebSocket.hs
@@ -187,8 +187,10 @@ choseSerializationMode
     -> (SerializationMode, Maybe SubProtocol)
 choseSerializationMode conn =
     case subProtocols conn of
-        ["compact"] -> (CompactSerialization, Just "compact")
+        [sub] | sub == compact -> (CompactSerialization, Just compact)
         _ -> (FullSerialization, Nothing)
+  where
+    compact = "ogmios.compact.v1"
 
 withOuroborosClients
     :: forall m a.

--- a/server/src/Ogmios/App/Server/WebSocket.hs
+++ b/server/src/Ogmios/App/Server/WebSocket.hs
@@ -263,7 +263,7 @@ withOuroborosClients mode sensors conn action = do
     chainSyncCodecs@ChainSyncCodecs
         { decodeFindIntersect
         , decodeRequestNext
-        } = mkChainSyncCodecs encodeBlock encodePoint encodeTip
+        } = mkChainSyncCodecs (encodeBlock mode) encodePoint encodeTip
 
     stateQueryCodecs@StateQueryCodecs
         { decodeAcquire

--- a/server/src/Ogmios/Control/MonadWebSocket.hs
+++ b/server/src/Ogmios/Control/MonadWebSocket.hs
@@ -20,10 +20,10 @@ module Ogmios.Control.MonadWebSocket
     , pingThreadDelay
     ) where
 
-import           Relude
+import Relude
 
-import           Network.WebSockets (Connection, ConnectionException (..),
-                                     Headers, PendingConnection)
+import Network.WebSockets
+    ( Connection, ConnectionException (..), Headers, PendingConnection )
 
 import qualified Network.WebSockets as WS
 

--- a/server/src/Ogmios/Control/MonadWebSocket.hs
+++ b/server/src/Ogmios/Control/MonadWebSocket.hs
@@ -3,29 +3,33 @@
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 module Ogmios.Control.MonadWebSocket
-  ( -- * Class
-    MonadWebSocket (..)
+    ( -- * Class
+      MonadWebSocket (..)
 
-    -- * Helpers
-  , WebSocketApp
-  , Connection
-  , PendingConnection
-  , ConnectionException (..)
-  , Headers
-  , headers
+      -- * Helpers
+    , WebSocketApp
+    , Connection
+    , PendingConnection
+    , ConnectionException (..)
+    , SubProtocol
+    , Headers
+    , headers
+    , subProtocols
 
-    -- * Constants
-  , pingThreadDelay
-  ) where
+      -- * Constants
+    , pingThreadDelay
+    ) where
 
-import Relude
+import           Relude
 
-import Network.WebSockets
-    ( Connection, ConnectionException (..), Headers, PendingConnection )
+import           Network.WebSockets (Connection, ConnectionException (..),
+                                     Headers, PendingConnection)
 
 import qualified Network.WebSockets as WS
 
 type WebSocketApp = PendingConnection -> IO ()
+
+type SubProtocol = ByteString
 
 class Monad m => MonadWebSocket (m :: Type -> Type) where
     receive
@@ -36,12 +40,17 @@ class Monad m => MonadWebSocket (m :: Type -> Type) where
         :: Connection -> ByteString -> m ()
     acceptRequest
         :: PendingConnection
+        -> Maybe SubProtocol
         -> (Connection -> m a)
         -> m a
 
 headers :: PendingConnection -> Headers
 headers =
     WS.requestHeaders . WS.pendingRequest
+
+subProtocols :: PendingConnection -> [ByteString]
+subProtocols =
+    WS.getRequestSubprotocols . WS.pendingRequest
 
 instance MonadWebSocket IO where
     receive =
@@ -50,8 +59,9 @@ instance MonadWebSocket IO where
         WS.sendTextData
     close =
         WS.sendClose
-    acceptRequest pending action = do
-        conn <- WS.acceptRequest pending
+    acceptRequest pending sub action = do
+        let accept = WS.defaultAcceptRequest { WS.acceptSubprotocol = sub }
+        conn <- WS.acceptRequestWith pending accept
         WS.withPingThread conn pingThreadDelay afterEachPing (action conn)
       where
         afterEachPing :: IO ()
@@ -64,9 +74,9 @@ instance MonadWebSocket m => MonadWebSocket (ReaderT env m) where
         lift . send conn
     close conn =
         lift . close conn
-    acceptRequest pending action = do
+    acceptRequest pending sub action = do
         env <- ask
-        lift $ acceptRequest pending (\conn -> runReaderT (action conn) env)
+        lift $ acceptRequest pending sub (\conn -> runReaderT (action conn) env)
 
 --
 -- Constants

--- a/server/src/Ogmios/Data/Json.hs
+++ b/server/src/Ogmios/Data/Json.hs
@@ -97,12 +97,13 @@ encodeAcquireFailure = \case
 
 encodeBlock
     :: Crypto crypto
-    => CardanoBlock crypto
+    => SerializationMode
+    -> CardanoBlock crypto
     -> Json
-encodeBlock = \case
+encodeBlock mode = \case
     BlockByron blk -> encodeObject
         [ ( "byron"
-          , Byron.encodeABlockOrBoundary (byronBlockRaw blk)
+          , Byron.encodeABlockOrBoundary mode (byronBlockRaw blk)
           )
         ]
     BlockShelley blk -> encodeObject

--- a/server/src/Ogmios/Data/Json.hs
+++ b/server/src/Ogmios/Data/Json.hs
@@ -8,6 +8,7 @@
 
 module Ogmios.Data.Json
     ( Json
+    , SerializationMode (..)
     , jsonToByteString
     , FromJSON
     , decodeWith

--- a/server/src/Ogmios/Data/Json.hs
+++ b/server/src/Ogmios/Data/Json.hs
@@ -108,17 +108,17 @@ encodeBlock mode = \case
         ]
     BlockShelley blk -> encodeObject
         [ ( "shelley"
-          , Shelley.encodeShelleyBlock blk
+          , Shelley.encodeShelleyBlock mode blk
           )
         ]
     BlockAllegra blk -> encodeObject
         [ ( "allegra"
-          , Allegra.encodeAllegraBlock blk
+          , Allegra.encodeAllegraBlock mode blk
           )
         ]
     BlockMary blk -> encodeObject
         [ ( "mary"
-          , Mary.encodeMaryBlock blk
+          , Mary.encodeMaryBlock mode blk
           )
         ]
 

--- a/server/src/Ogmios/Data/Json/Mary.hs
+++ b/server/src/Ogmios/Data/Json/Mary.hs
@@ -69,15 +69,16 @@ encodeLedgerFailure = \case
 
 encodeMaryBlock
     :: Crypto crypto
-    => ShelleyBlock (MaryEra crypto)
+    => SerializationMode
+    -> ShelleyBlock (MaryEra crypto)
     -> Json
-encodeMaryBlock (ShelleyBlock (Sh.Block blkHeader txs) headerHash) =
+encodeMaryBlock mode (ShelleyBlock (Sh.Block blkHeader txs) headerHash) =
     encodeObject
     [ ( "body"
-      , encodeFoldable encodeTx (Sh.txSeqTxns' txs)
+      , encodeFoldable (encodeTx mode) (Sh.txSeqTxns' txs)
       )
     , ( "header"
-      , Shelley.encodeBHeader blkHeader
+      , Shelley.encodeBHeader mode blkHeader
       )
     , ( "headerHash"
       , Shelley.encodeShelleyHash headerHash
@@ -99,17 +100,15 @@ encodeProposedPPUpdates =
 
 encodeTx
     :: Crypto crypto
-    => Sh.Tx (MaryEra crypto)
+    => SerializationMode
+    -> Sh.Tx (MaryEra crypto)
     -> Json
-encodeTx x = encodeObject
+encodeTx mode x = encodeObjectWithMode mode
     [ ( "id"
       , Shelley.encodeTxId (Sh.txid (Sh._body x))
       )
     , ( "body"
       , encodeTxBody (Sh._body x)
-      )
-    , ( "witness"
-      , encodeWitnessSet (Sh._witnessSet x)
       )
     , ( "metadata", encodeObject
         [ ( "hash"
@@ -119,6 +118,10 @@ encodeTx x = encodeObject
           , encodeStrictMaybe encodeAuxiliaryData (Sh._metadata x)
           )
         ]
+      )
+    ]
+    [ ( "witness"
+      , encodeWitnessSet (Sh._witnessSet x)
       )
     ]
   where

--- a/server/test/unit/Ogmios/Data/JsonSpec.hs
+++ b/server/test/unit/Ogmios/Data/JsonSpec.hs
@@ -29,6 +29,7 @@ import Data.Type.Equality
     ( (:~:) (..), testEquality )
 import Ogmios.Data.Json
     ( Json
+    , SerializationMode (..)
     , encodeAcquireFailure
     , encodeBlock
     , encodeHardForkApplyTxErr
@@ -175,7 +176,7 @@ spec = do
 
         validateToJSON
             (arbitrary @(Wsp.Response (RequestNextResponse Block)))
-            (_encodeRequestNextResponse encodeBlock encodePoint encodeTip)
+            (_encodeRequestNextResponse (encodeBlock FullSerialization) encodePoint encodeTip)
             "ogmios.wsp.json#/properties/RequestNextResponse"
 
     context "validate tx submission req/res against JSON-schema" $ do


### PR DESCRIPTION
Ticket: #9 

- [x] Allow websocket clients to pass sub-protocols; sub-protocols currently include and are limited to `compact`
- [x] When requesting `compact`, Ogmios will not serialize proofs, signatures and other voluminous elements in responses of the chain-sync protocols. The rationale is that in a confidential setup, where clients fully trust their node / Ogmios, there's no need to verify these and it should be possible to shave some bits off the responses. 
    - [x] Byron
    - [x] Shelley
    - [x] Allegra
    - [x] Mary  
- [x] Fix unit tests accordingly
- [x] Add smoke-tests for compact and full mode. 
- [x] Document in the user-guide and JSON-schema. 

--- 

Some preliminary results: 

<details>
    <summary>Byron</summary>

**mode**: full

```json
{
  "totalBlocks": 50000,
  "totalTime": "5.172s",
  "totalSize": "90.61MB",
  "block/s": "9667",
  "MB/s": "18"
}
```


**mode**: compact

```json
{
  "totalBlocks": 50000,
  "totalTime": "3.965s",
  "totalSize": "43.89MB",
  "block/s": "12610",
  "MB/s": "11"
}
```
</details>

<details>
    <summary>Shelley</summary>

**mode**: full

```json
{
  "totalBlocks": 50000,
  "totalTime": "9.259s",
  "totalSize": "233.75MB",
  "block/s": "5400",
  "MB/s": "25"
}
```


**mode**: compact

```json
{
  "totalBlocks": 50000,
  "totalTime": "6.799s",
  "totalSize": "117.76MB",
  "block/s": "7354",
  "MB/s": "17"
}
```
</details>

<details>
    <summary>Allegra</summary>

**mode**: full

```json
{
  "totalBlocks": 50000,
  "totalTime": "9.864s",
  "totalSize": "207.06MB",
  "block/s": "5069",
  "MB/s": "21"
}
```


**mode**: compact

```json
{
  "totalBlocks": 50000,
  "totalTime": "7.861s",
  "totalSize": "100.84MB",
  "block/s": "6361",
  "MB/s": "13"
}
```
</details>

<details>
    <summary>Mary</summary>

**mode**: full

```json
{   
  "totalBlocks": 50000,
  "totalTime": "34.846s",
  "totalSize": "619.33MB",
  "block/s": "1435",
  "MB/s": "18"
}
```

**mode**: compact

```json
{
  "totalBlocks": 50000,
  "totalTime": "29.356s",
  "totalSize": "354.41MB",
  "block/s": "1703",
  "MB/s": "12"
}
```
</details>

Some more results:

##### Full chain-sync (without sub-protocols support)

Byron synchronized in 13.67 min
Shelley synchronized in 1.67 min
Allegra synchronized in 2.27 min
Mary synchronized in 2.43 min
========================================= 20min 02s


##### Full chain-sync (with sub-protocols support, but no sub-protocol enabled)

Byron synchronized in 13.45 min
Shelley synchronized in 1.64 min
Allegra synchronized in 2.53 min
Mary synchronized in 2.35 min
========================================= 19min 58s

##### Full chain-sync (with sub-protocols support, and "ogmios.compact.v1" enabled)

Byron synchronized in 11.35 min
Shelley synchronized in 1.25 min
Allegra synchronized in 2.09 min
Mary synchronized in 2.02 min
========================================= 16min 43s (-17%)




