### PR TITLE
Add network synchronization to health object 

### DIFF
--- a/docs/content/getting-started/monitoring.md
+++ b/docs/content/getting-started/monitoring.md
@@ -42,7 +42,9 @@ $ curl -H 'Accept: application/json' http://localhost:1337/health
         "hash": "c29428f386c701c1d1ba1fd259d4be78921ee9ee6c174eac898245ceb55e8061",
         "blockNo": 5034297,
         "slot": 15520688
-    }
+    },
+    "networkSynchronization": 0.99,
+    "currentEra": "Mary"
 }
 ```
 
@@ -53,6 +55,8 @@ All information are computed at runtime and **not preserved between restarts** (
 | `startTime`                            | UTC timestamp at which the server was started.                                                                           |
 | `lastTipUpdate`                        | UTC timestamp when `lastKnownTip` was last updated (can be `null`)                                                       |
 | `lastKnownTip`                         | Last known chain tip received from the node (can be `null`)                                                              |
+| `networkSynchronization`               | A percentage indicator of how far the server/node is from the network tip. `1` means it is synchronized.                 |
+| `currentEra`                           | The current Cardano era of the underlying node. Useful for state-queries and debugging.                                  |
 | `metrics.activeConnections`            | Number of WebSocket connections currently established with the server.                                                   |
 | `metrics.totalConnections`             | Total number of WebSocket connections established with the server since it's started.                                    |
 | `metrics.sessionDurations`             | Some time measures (`min`, `max`, `mean`) of the duration of each sessions, in milliseconds.                             |

--- a/server/.hlint.yaml
+++ b/server/.hlint.yaml
@@ -53,6 +53,7 @@
 - ignore: {name: "Use ?~"} # It's actually much clearer to do (.~ Just ...) than having to load yet-another-lens-operator
 - ignore: {name: "Use newtype instead of data"} # The semantic is slightly different, sometimes
 - ignore: {name: "Use newTMVarIO"}
+- ignore: {name: "Use newEmptyTMVarIO"}
 - ignore: {name: "Use newTVarIO"}
 
 # Add custom hints for this project

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -13,6 +13,9 @@ pre: "<b>5. </b>"
   Ogmios will omit fields such as witnesses, proofs and signatures from responses to make responses smaller.
 - JSON-WSP faults are now documented in the JSON schema
 - Continuous integration job checking for code style and lint on the server source code.
+- The `/health` endpoint now returns two additional pieces of information:
+  - A `networkSynchronization` percentage to indicate how far Ogmios / the node is from the network.
+  - A `currentEra` value to indicate the corresponding Cardano era Ogmios / the node is currently running in.
 
 #### Changed
 

--- a/server/src/Ogmios/App/Options.hs
+++ b/server/src/Ogmios/App/Options.hs
@@ -238,8 +238,7 @@ stagingNetworkParameters =
     NetworkParameters
         { networkMagic = NetworkMagic 633343913
         , slotsPerEpoch = defaultSlotsPerEpoch
-        -- FIXME: Find staging's system start time?
-        , systemStart = SystemStart $ posixSecondsToUTCTime 1563999616
+        , systemStart = SystemStart $ posixSecondsToUTCTime 1506450213
         }
 
 -- Hard-coded genesis slots per epoch

--- a/server/src/Ogmios/App/Protocol/StateQuery.hs
+++ b/server/src/Ogmios/App/Protocol/StateQuery.hs
@@ -79,6 +79,12 @@ import qualified Ouroboros.Consensus.HardFork.Combinator as LSQ
 import qualified Ouroboros.Consensus.Shelley.Ledger.Query as Ledger
 import qualified Ouroboros.Network.Protocol.LocalStateQuery.Client as LSQ
 
+-- | A generic state-query client, which receives commands from a queue, and
+-- yield results as JSON.
+--
+-- This client is meant to be driven by another client (e.g. from a WebSocket
+-- connection) and simply ensures correct execution of the state-query protocol.
+-- In particular, it also makes it easier to run queries _in the current era_.
 mkStateQueryClient
     :: forall m crypto block.
         ( MonadThrow m

--- a/server/src/Ogmios/App/Server/Http.hs
+++ b/server/src/Ogmios/App/Server/Http.hs
@@ -100,7 +100,11 @@ getHealthR :: Handler Server
 getHealthR = runHandlerM $ do
     header "Access-Control-Allow-Origin" "*"
     Server unliftIO EnvServer{health,sensors,sampler} <- sub
-    let readTipInfo = (\h -> (lastKnownTip h, networkSynchronization h)) <$> readTVar health
+    let readTipInfo = (\h ->
+            ( lastKnownTip h
+            , networkSynchronization h
+            , currentEra h
+            )) <$> readTVar health
     json =<< liftIO (unliftIO $ healthCheck readTipInfo health sensors sampler)
 
 getTestsR :: Handler Server

--- a/server/src/Ogmios/App/Server/Http.hs
+++ b/server/src/Ogmios/App/Server/Http.hs
@@ -100,8 +100,8 @@ getHealthR :: Handler Server
 getHealthR = runHandlerM $ do
     header "Access-Control-Allow-Origin" "*"
     Server unliftIO EnvServer{health,sensors,sampler} <- sub
-    let readTip = lastKnownTip <$> readTVar health
-    json =<< liftIO (unliftIO $ healthCheck readTip health sensors sampler)
+    let readTipInfo = (\h -> (lastKnownTip h, networkSynchronization h)) <$> readTVar health
+    json =<< liftIO (unliftIO $ healthCheck readTipInfo health sensors sampler)
 
 getTestsR :: Handler Server
 getTestsR = runHandlerM $ do

--- a/server/src/Ogmios/Control/MonadSTM.hs
+++ b/server/src/Ogmios/Control/MonadSTM.hs
@@ -18,6 +18,7 @@ module Ogmios.Control.MonadSTM
 
     , TMVar
     , newTMVar
+    , newEmptyTMVar
     , putTMVar
     , takeTMVar
     , tryTakeTMVar

--- a/server/src/Ogmios/Data/Health.hs
+++ b/server/src/Ogmios/Data/Health.hs
@@ -11,10 +11,8 @@ module Ogmios.Data.Health
       -- ** NetworkSynchronization
     , NetworkSynchronization
     , mkNetworkSynchronization
-
-    , SystemStart(..)
-    , RelativeTime(..)
-    , fromRelativeTime
+      -- ** CardanoEra
+    , CardanoEra (..)
     ) where
 
 import Relude
@@ -27,7 +25,7 @@ import Data.Aeson
 import Data.Time.Clock
     ( UTCTime, diffUTCTime )
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types
-    ( RelativeTime (..), SystemStart (..), fromRelativeTime )
+    ( RelativeTime (..), SystemStart (..) )
 import Ouroboros.Network.Block
     ( Tip (..) )
 
@@ -46,7 +44,9 @@ data Health block = Health
     , lastTipUpdate :: !(Maybe UTCTime)
     -- ^ Date at which the last update was received.
     , networkSynchronization :: !NetworkSynchronization
-    -- ^ Percentage indicator of how far our node is from the network
+    -- ^ Percentage indicator of how far the node is from the network.
+    , currentEra :: !CardanoEra
+    -- ^ Current node's era.
     , metrics :: !Metrics
     -- ^ Application metrics measured at regular interval
     } deriving (Generic, Eq, Show)
@@ -60,6 +60,7 @@ emptyHealth startTime = Health
     , lastKnownTip = TipGenesis
     , lastTipUpdate = Nothing
     , networkSynchronization = NetworkSynchronization 0
+    , currentEra = Byron
     , metrics = emptyMetrics
     }
 
@@ -89,3 +90,16 @@ mkNetworkSynchronization systemStart now relativeSlotTime =
         p = 100
     in
         NetworkSynchronization $ fromIntegral (num * p `div` den) / fromIntegral p
+
+
+-- | A Cardano era, starting from Byron and onwards.
+data CardanoEra
+    = Byron
+    | Shelley
+    | Allegra
+    | Mary
+    | Alonzo
+    deriving (Generic, Show, Eq, Enum, Bounded)
+
+instance ToJSON CardanoEra where
+    toJSON = genericToJSON Json.defaultOptions


### PR DESCRIPTION
### Logs

```
[ogmios:Info:25] [2021-04-17 21:51:04.43 UTC] OgmiosHealth {healthCheck = HealthTick {status = Health {startTime = 2021-04-17 21:49:44.379862746 UTC, lastKnownTip = Tip (SlotNo 23727880) 514320620f62ecd7e75ea5de13668a5fb9f182d04aa28ffcc1e53497b0f42530 (BlockNo 2482974), lastTipUpdate = Just 2021-04-17 21:51:04.437438569 UTC, networkSynchronization = NetworkSynchronization 0.98, metrics = Metrics {runtimeStats = RuntimeStats {maxHeapSize = 240, currentHeapSize = 496, cpuTime = 6212560918, gcCpuTime = 35185618}, activeConnections = 0, totalConnections = 0, sessionDurations = DistributionStats {mean = 0.0, min = 0.0, max = 0.0}, totalMessages = 0, totalUnrouted = 0}}}}
```

### JSON

```json
{
  "metrics": {
    "totalUnrouted": 0,
    "totalMessages": 0,
    "runtimeStats": {
      "gcCpuTime": 61798742,
      "cpuTime": 426328913,
      "maxHeapSize": 251,
      "currentHeapSize": 251
    },
    "totalConnections": 0,
    "sessionDurations": {
      "max": 0,
      "mean": 0,
      "min": 0
    },
    "activeConnections": 0
  },
  "startTime": "2021-04-17T21:33:53.579815077Z",
  "lastTipUpdate": "2021-04-17T21:34:05.533587979Z",
  "lastKnownTip": {
    "hash": "6f7986df8bcf68ccac0dae400312b06d731f048adb5f7bc5ec3d064e0b9c16c8",
    "blockNo": 2465990,
    "slot": 23161199
  },
  "networkSynchronization": 0.98,
  "currentEra": "Mary"
}
```
