### PR TITLE
Feature: ChainSyncClient.startSync

### DIFF
--- a/clients/TypeScript/README.md
+++ b/clients/TypeScript/README.md
@@ -14,6 +14,10 @@ yarn build
 ```
 #### Run Tests
 ```console
+yarn testnet:up
+```
+In another terminal
+```console
 yarn test
 ```
 
@@ -39,7 +43,7 @@ yarn testnet:down
 ### Start the REPL
 #### mainnet
 ```console
-yarn repl
+yarn repl:start
 ```
 #### testnet
 ```console

--- a/clients/TypeScript/packages/client/src/ChainSync/ChainSyncClient.ts
+++ b/clients/TypeScript/packages/client/src/ChainSync/ChainSyncClient.ts
@@ -79,7 +79,7 @@ export const createChainSyncClient = async (options?: {
               }
             )
             ensureSocketIsOpen(socket)
-            for (let n = 0; n <= (requestBuffer || 100); n += 1) {
+            for (let n = 0; n < (requestBuffer || 100); n += 1) {
               requestNext(socket)
             }
             return intersection

--- a/clients/TypeScript/packages/client/src/ChainSync/index.ts
+++ b/clients/TypeScript/packages/client/src/ChainSync/index.ts
@@ -1,2 +1,3 @@
 export * from './ChainSyncClient'
 export * from './findIntersect'
+export * from './requestNext'

--- a/clients/TypeScript/packages/client/src/ChainSync/requestNext.ts
+++ b/clients/TypeScript/packages/client/src/ChainSync/requestNext.ts
@@ -1,0 +1,15 @@
+import { Ogmios } from '@cardano-ogmios/schema'
+import { baseRequest } from '../Request'
+import { Mirror } from '../Connection'
+import WebSocket from 'isomorphic-ws'
+
+export const requestNext = (
+  socket: WebSocket,
+  options?: { mirror?: Mirror }
+): void => {
+  socket.send(JSON.stringify({
+    ...baseRequest,
+    methodname: 'RequestNext',
+    mirror: options?.mirror
+  } as Ogmios['RequestNext']))
+}

--- a/clients/TypeScript/packages/client/test/ChainSync.test.ts
+++ b/clients/TypeScript/packages/client/test/ChainSync.test.ts
@@ -18,69 +18,103 @@ describe('ChainSync', () => {
     expect(client.context.socket.readyState).toBe(client.context.socket.OPEN)
     await client.shutdown()
   })
-  it('selects the tip as the intersection if no point provided', async () => {
-    const client = await createChainSyncClient({ connection })
-    if (client.initialIntersection.point === 'origin' || client.initialIntersection.tip === 'origin') {
+
+  describe('startSync', () => {
+    it('selects the tip as the intersection if no point provided', async () => {
+      const client = await createChainSyncClient({ connection })
+      const intersection = await client.startSync()
+      if (intersection.point === 'origin' || intersection.tip === 'origin') {
+        await client.shutdown()
+        throw new Error('Test network is not syncing')
+      } else if ('slot' in intersection.point && 'slot' in intersection.tip) {
+        expect(intersection.point.slot).toEqual(intersection.tip.slot)
+        expect(intersection.point.hash).toEqual(intersection.tip.hash)
+      }
       await client.shutdown()
-      throw new Error('Test network is not syncing')
-    } else if ('slot' in client.initialIntersection.point && 'slot' in client.initialIntersection.tip) {
-      expect(client.initialIntersection.point.slot).toEqual(client.initialIntersection.tip.slot)
-      expect(client.initialIntersection.point.hash).toEqual(client.initialIntersection.tip.hash)
-    }
-    await client.shutdown()
+    })
+
+    it('intersects at the genesis if origin provided as point', async () => {
+      const client = await createChainSyncClient({ connection })
+      const intersection = await client.startSync(['origin'])
+      expect(intersection.point).toEqual('origin')
+      expect(intersection.tip).toBeDefined()
+      await client.shutdown()
+    })
+
+    it('accepts message handlers for roll back and roll forward messages', async () => {
+      const rollbackPoints: Point[] = []
+      const blocks: Block[] = []
+      const client = await createChainSyncClient({ connection })
+      client.on({
+        rollBackward: ({ point }) => {
+          rollbackPoints.push(point)
+          client.requestNext()
+        },
+        rollForward: async ({ block }) => {
+          if (blocks.length < 10) {
+            blocks.push(block)
+            client.requestNext()
+          }
+        }
+      })
+      await client.startSync(['origin'], 10)
+      await delay(1000)
+      await client.shutdown()
+      let firstBlockHash: Hash16
+      if ('byron' in blocks[0]) {
+        const block = blocks[0] as { byron: BlockByron }
+        firstBlockHash = block.byron.hash
+      } else if ('shelley' in blocks[0]) {
+        const block = blocks[0] as { shelley: BlockShelley }
+        firstBlockHash = block.shelley.body[0].id
+      } else if ('allegra' in blocks[0]) {
+        const block = blocks[0] as { allegra: BlockAllegra }
+        firstBlockHash = block.allegra.body[0].id
+      } else if ('mary' in blocks[0]) {
+        const block = blocks[0] as { mary: BlockMary }
+        firstBlockHash = block.mary.body[0].id
+      }
+      expect(firstBlockHash).toBeDefined()
+      expect(rollbackPoints.length).toBe(1)
+      expect(blocks.length).toBe(10)
+    })
+
+    it('implements pipelining to increase sync performance', async () => {
+      type BlocksPerSecond = number
+      const run = async (requestBuffer?: number): Promise<BlocksPerSecond> => {
+        const blocks: Block[] = []
+        const client = await createChainSyncClient({ connection })
+        const start = Date.now()
+        let stop: number
+        client.on({
+          rollBackward: () => {
+            client.requestNext()
+          },
+          rollForward: async ({ block }) => {
+            if (blocks.length < 1000) {
+              blocks.push(block)
+              client.requestNext()
+            } else if (stop === undefined) {
+              stop = Date.now() - start
+            }
+          }
+        })
+        await client.startSync(['origin'], requestBuffer)
+        await delay(800)
+        await client.shutdown()
+        expect(blocks.length).toBe(1000)
+        return 1000 * blocks.length / stop
+      }
+      const pipelinedBlocksPerSecond = await run()
+      const nonPipelinedBlocksPerSecond = await run(1)
+      expect(pipelinedBlocksPerSecond).toBeGreaterThan(nonPipelinedBlocksPerSecond)
+    })
   })
-  it('intersects at the genesis if origin provided as point', async () => {
-    const client = await createChainSyncClient({ connection })
-    const intersection = await client.findIntersect(['origin'])
-    expect(intersection.point).toEqual('origin')
-    expect(intersection.tip).toBeDefined()
-    await client.shutdown()
-  })
+
   it('rejects method calls after shutdown', async () => {
     const client = await createChainSyncClient({ connection })
     await client.shutdown()
-    const run = () => client.findIntersect(['origin'])
+    const run = () => client.startSync(['origin'])
     await expect(run).rejects
-  })
-  it('accepts message handlers for roll back and roll forward messages', async () => {
-    const rollbackPoints: Point[] = []
-    let count = 1
-    const blocks: Block[] = []
-    const client = await createChainSyncClient({ connection })
-    await client.findIntersect(['origin'])
-    client.on({
-      rollBackward: ({ point, reflection }) => {
-        rollbackPoints.push(point)
-        client.requestNext({ mirror: reflection })
-      },
-      rollForward: async ({ block, reflection }) => {
-        blocks.push(block)
-        count = reflection.count as number
-        if (reflection.count < 10) {
-          client.requestNext({ mirror: { count: reflection.count as number + 1 } })
-        } else {
-          await client.shutdown()
-        }
-      }
-    })
-    client.requestNext({ mirror: { count } })
-    await delay(100)
-    let firstBlockHash: Hash16
-    if ('byron' in blocks[0]) {
-      const block = blocks[0] as { byron: BlockByron }
-      firstBlockHash = block.byron.hash
-    } else if ('shelley' in blocks[0]) {
-      const block = blocks[0] as { shelley: BlockShelley }
-      firstBlockHash = block.shelley.body[0].id
-    } else if ('allegra' in blocks[0]) {
-      const block = blocks[0] as { allegra: BlockAllegra }
-      firstBlockHash = block.allegra.body[0].id
-    } else if ('mary' in blocks[0]) {
-      const block = blocks[0] as { mary: BlockMary }
-      firstBlockHash = block.mary.body[0].id
-    }
-    expect(firstBlockHash).toBeDefined()
-    expect(rollbackPoints.length).toBe(1)
-    expect(count).toBe(10)
   })
 })

--- a/clients/TypeScript/packages/repl/README.md
+++ b/clients/TypeScript/packages/repl/README.md
@@ -36,7 +36,7 @@ ogmios> await currentProtocolParameters()
   treasuryExpansion: '1/5'
 }
 
-ogmios> chainSync.requestNext()
+ogmios> chainSync.startSync()
 ogmios> ROLL BACKWARD
 Point
 {
@@ -50,7 +50,6 @@ Tip
   slot: 25551480
 }
 
-ogmios> chainSync.requestNext()
 ogmios> ROLL FORWARD
 Block
 {

--- a/clients/TypeScript/packages/repl/src/index.ts
+++ b/clients/TypeScript/packages/repl/src/index.ts
@@ -1,6 +1,7 @@
 import repl from 'repl'
 import parser from 'yargs-parser'
 import {
+  ChainSyncMessageHandlers,
   createChainSyncClient,
   createStateQueryClient,
   currentEpoch,
@@ -30,8 +31,7 @@ const logObject = (obj: Object) =>
     host: args.host,
     port: args.port
   }
-  const chainSync = await createChainSyncClient({ connection })
-  chainSync.on({
+  const chainSync = await createChainSyncClient({
     rollBackward: ({ point, tip, reflection }) => {
       log(chalk.bgRedBright.bold('ROLL BACKWARD'))
       log(chalk.redBright.bold('Point'))
@@ -54,6 +54,8 @@ const logObject = (obj: Object) =>
         logObject(reflection)
       }
     }
+  }, {
+    connection
   })
   const cardanoOgmiosRepl = repl.start({
     prompt: 'ogmios> ',
@@ -62,17 +64,21 @@ const logObject = (obj: Object) =>
 
   Object.assign(cardanoOgmiosRepl.context, {
     chainSync,
-    createChainSyncClient: () => createChainSyncClient({ connection }),
+    createChainSyncClient:
+      (messageHandlers: ChainSyncMessageHandlers) =>
+        createChainSyncClient(messageHandlers, { connection }),
     createStateQueryClient: () => createStateQueryClient({ connection }),
     currentEpoch: () => currentEpoch({ connection }),
     currentProtocolParameters: () => currentProtocolParameters({ connection }),
-    delegationsAndRewards: (stakeKeyHashes: Schema.Hash16[]) => delegationsAndRewards(stakeKeyHashes, { connection }),
+    delegationsAndRewards:
+      (stakeKeyHashes: Schema.Hash16[]) => delegationsAndRewards(stakeKeyHashes, { connection }),
     eraStart: () => eraStart({ connection }),
     genesisConfig: () => genesisConfig({ connection }),
     findIntersect: (points: Schema.Point[]) => findIntersect(points, { connection }),
     ledgerTip: () => ledgerTip({ connection }),
     nonMyopicMemberRewards:
-      (input: (Schema.Lovelace | Schema.Hash16)[]) => nonMyopicMemberRewards(input, { connection }),
+      (input: (Schema.Lovelace | Schema.Hash16)[]) =>
+        nonMyopicMemberRewards(input, { connection }),
     proposedProtocolParameters: () => proposedProtocolParameters({ connection }),
     stakeDistribution: () => stakeDistribution({ connection }),
     submitTx: (bytes: string) => submitTx(bytes, { connection }),

--- a/server/static/tests/chain-sync.js
+++ b/server/static/tests/chain-sync.js
@@ -81,7 +81,7 @@ const lastAllegraBlock = {
             default:
               if (!didBootstrap) {
                 didBootstrap = true;
-                for(let n = 0; n <= N_BOOTSTRAP; n += 1) {
+                for(let n = 0; n < N_BOOTSTRAP; n += 1) {
                   client.ogmios("RequestNext");
                 }
               } else {


### PR DESCRIPTION
Adds a function to handle the sync setup, including request pipelining
to optimize performance. The default is 100 requests, but it's a configurable
argument. The `ChainSyncClient` no longer exposes `findIntersect`, and the awkward
`initialIntersection` logic removed.

- [x] Update REPL
- [x] Resolve open handle in the test suite
- [x] Fix CI workflow