### PR TITLE
Allow passing slots per epochs to the network parameter env var

### DIFF
--- a/server/package.yaml
+++ b/server/package.yaml
@@ -138,5 +138,6 @@ tests:
     - relude
     - shelley-spec-ledger
     - shelley-spec-ledger-test
+    - time
     build-tools:
     - hspec-discover

--- a/server/src/Ogmios/App/Options.hs
+++ b/server/src/Ogmios/App/Options.hs
@@ -24,10 +24,22 @@ module Ogmios.App.Options
     , logLevelOption
 
       -- ** Environment
+      -- *** ENV Var
+    , envOgmiosNetwork
+
+      -- *** Types
     , NetworkParameters (..)
+    , mainnetNetworkParameters
+    , testnetNetworkParameters
+    , stagingNetworkParameters
+
     , NetworkMagic (..)
     , EpochSlots (..)
-    , envOgmiosNetwork
+    , defaultSlotsPerEpoch
+    , SystemStart (..)
+    , mkSystemStart
+
+      -- *** Parsing 'NetworkParameters'
     , lookupNetworkParameters
     , parseNetworkParameters
     ) where
@@ -302,3 +314,9 @@ separator =
 readAsPosixTime :: String -> Maybe UTCTime
 readAsPosixTime =
     fmap posixSecondsToUTCTime . readMay . (<> "s")
+
+mkSystemStart :: Int -> SystemStart
+mkSystemStart =
+    SystemStart . posixSecondsToUTCTime . toPicoResolution . toEnum
+  where
+    toPicoResolution = (*1000000000000)

--- a/server/test/unit/Ogmios/App/OptionsSpec.hs
+++ b/server/test/unit/Ogmios/App/OptionsSpec.hs
@@ -1,0 +1,116 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+module Ogmios.App.OptionsSpec
+    ( spec
+    ) where
+
+import Ogmios.Prelude
+
+import Ogmios.App.Options
+    ( EpochSlots (..)
+    , NetworkMagic (..)
+    , NetworkParameters (..)
+    , SystemStart (..)
+    , defaultSlotsPerEpoch
+    , mainnetNetworkParameters
+    , mkSystemStart
+    , parseNetworkParameters
+    , stagingNetworkParameters
+    , testnetNetworkParameters
+    )
+
+import Data.Time.Clock.POSIX
+    ( posixSecondsToUTCTime )
+import Test.Hspec
+    ( Spec, context, parallel )
+import Test.Hspec.QuickCheck
+    ( prop )
+import Test.QuickCheck
+    ( Arbitrary (..)
+    , Gen
+    , Property
+    , choose
+    , conjoin
+    , elements
+    , forAll
+    , property
+    , (===)
+    )
+
+spec :: Spec
+spec = parallel $ do
+    context "parseNetworkParameters" $ do
+        parallel $ prop "Parse any combination of 2 colon-separated naturals"
+            prop_any2ParseNetworkParameters
+
+        parallel $ prop "Parse any combination of 3 colon-separated naturals"
+            prop_any3ParseNetworkParameters
+
+        parallel $ prop  "Parse well-known networks strings"
+            prop_wellKnownParseNetworkParameters
+
+prop_any3ParseNetworkParameters :: Property
+prop_any3ParseNetworkParameters =
+    forAll genNetworkParameters $ \((a, magic), (b, start), (c, slots)) -> do
+        case parseNetworkParameters (intercalate ":" [a,b,c]) of
+            Nothing ->
+                property False
+            Just params -> conjoin
+                [ networkMagic params === magic
+                , systemStart params === start
+                , slotsPerEpoch params === slots
+                ]
+  where
+    genNetworkParameters = (,,)
+        <$> genNetworkMagic
+        <*> genSystemStart
+        <*> genSlotsPerEpoch
+
+prop_any2ParseNetworkParameters :: Property
+prop_any2ParseNetworkParameters =
+    forAll genNetworkParameters $ \((a, magic), (b, start)) -> do
+        case parseNetworkParameters (intercalate ":" [a,b]) of
+            Nothing ->
+                property False
+            Just params -> conjoin
+                [ networkMagic params === magic
+                , systemStart params === start
+                , slotsPerEpoch params === defaultSlotsPerEpoch
+                ]
+  where
+    genNetworkParameters = (,)
+        <$> genNetworkMagic
+        <*> genSystemStart
+
+
+prop_wellKnownParseNetworkParameters :: Property
+prop_wellKnownParseNetworkParameters =
+    forAll genNetworkParameters $ \(str, params) -> do
+        parseNetworkParameters str === Just params
+  where
+    genNetworkParameters = elements
+        [ ( "mainnet", mainnetNetworkParameters )
+        , ( "testnet", testnetNetworkParameters )
+        , ( "staging", stagingNetworkParameters )
+        ]
+
+--
+-- Generators
+--
+
+genNetworkMagic :: Gen (String, NetworkMagic)
+genNetworkMagic = do
+    m <- arbitrary
+    pure (show m, NetworkMagic m)
+
+genSystemStart :: Gen (String, SystemStart)
+genSystemStart = do
+    t <- choose (0, fromIntegral (maxBound :: Word32))
+    pure (show t, mkSystemStart t)
+
+genSlotsPerEpoch :: Gen (String, EpochSlots)
+genSlotsPerEpoch = do
+    s <- choose (0, 100000)
+    pure (show s, EpochSlots s)


### PR DESCRIPTION
Fixes #35 

- c69e8ce593f497b44a017d59495ffe5dc550f6de
  :round_pushpin: **Allow passing slots per epochs to the network parameter env var**
  
- 77e30bb9d74c98e483eb36795ef634810ad911fb
  :round_pushpin: **Add property test checking for 'parseNetworkParameters'**

Also reworked the command-line `--help` to provide some concrete examples of the `OGMIOS_NETWORK` env var:

```console
$ ogmios --help
Provides a bridge between cardano-node and WebSocket clients. Ogmios translates
the existing CBOR-based Ouroboros mini-protocols into JSON-WSP-based protocols,
through WebSocket channels.

Usage: ogmios ((-v|--version) | --node-socket FILEPATH [--host IPv4] 
                [--port TCP/PORT] [--timeout SECONDS] [--log-level SEVERITY])
  Ogmios - A JSON-WSP WebSocket adaptor for cardano-node

Available options:
  -h,--help                Show this help text
  -v,--version             Show the software current version and build revision.
  --node-socket FILEPATH   Path to the node socket.
  --host IPv4              Address to bind to. (default: "127.0.0.1")
  --port TCP/PORT          Port to listen on. (default: 1337)
  --timeout SECONDS        Number of seconds of inactivity after which the
                           server should close client connections. (default: 90)
  --log-level SEVERITY     Minimal severity required for logging.
                           --------------------
                           - Debug
                           - Info
                           - Notice
                           - Warning
                           - Error
                           - Critical
                           - Alert
                           - Emergency
                           -------------------- (default: Info)

Available commands:
  version                  Show the software current version and build revision.

Available ENV variables:
  OGMIOS_NETWORK           Configure the target network.
                           --------------------
                           - mainnet
                           - testnet
                           - staging
                           - <MAGIC>:<SYSTEM-START>[:<SLOTS-PER-EPOCH]
                           -------------------- (default: mainnet)

Examples:
  Connecting to the mainnet:
    $ ogmios --node-socket /path/to/node.socket

  Connecting to the testnet:
    $ OGMIOS_NETWORK=testnet ogmios --node-socket /path/to/node.socket

  Connecting to the testnet using explicit parameters:
    $ OGMIOS_NETWORK=1097911063:1563999616 ogmios --node-socket /path/to/node.socket

  Connecting to the Guild network:
    $ OGMIOS_NETWORK=141:1612317107:3600 ogmios --node-socket /path/to/node.socket
```

