### PR TITLE
Fix 'Acquire' definition and add extra automated tests for JSON *request* schemas 

### DIFF
--- a/docs/static/ogmios.wsp.json
+++ b/docs/static/ogmios.wsp.json
@@ -316,7 +316,7 @@
         , "additionalProperties": false
         , "required": ["point"]
         , "properties":
-          { "points": { "$ref": "#/definitions/Point" }
+          { "point": { "$ref": "#/definitions/Point" }
           }
         }
       , "mirror":

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -9,6 +9,11 @@ pre: "<b>5. </b>"
 
 #### Added
 
+- New TypeScript client! The client comes in three packages:
+  - An interactive REPL to play with Ogmios using the command-line.
+  - A generator to derive TypeScript type definitions from the JSON schema.
+  - The actual client library providing nice wrapper around the various protocol, in a typed way.
+  The TypeScript client also includes a new battery of automated integration tests against the testnet. 
 - Support for WebSocket sub-protocols, with currently one support sub-protocol: `ogmios.compact.v1`. When enabled,
   Ogmios will omit fields such as witnesses, proofs and signatures from responses to make responses smaller.
 - Provide missing documentation / JSON-schema for:
@@ -27,12 +32,15 @@ pre: "<b>5. </b>"
 - The `/health` endpoint now returns two additional pieces of information:
   - A `networkSynchronization` percentage to indicate how far Ogmios / the node is from the network.
   - A `currentEra` value to indicate the corresponding Cardano era Ogmios / the node is currently running in.
+- Nix support for building Ogmios (this also include a `cabal.project` to enable cabal support as well).
 
 #### Changed
 
 - Rework Docker setup to not require an external snapshot image. Everything is now built in a single
   `Dockerfile`, but cache from DockerHub can be leveraged to reduce overall build time when building
   from scratch.
+- Fixed typo in the JSON-schema w.r.t to the 'Acquire' request (`points` → `point`), and introduce more automated test
+  to catch this kind of errors more easily. 
 
 #### Removed
 

--- a/server/modules/json-wsp/CHANGELOG.md
+++ b/server/modules/json-wsp/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [1.1.0] -- 2021-05-06
+
+### Added
+
+- `mkResponse` for constructing a JSON value from a WSP response.
+- `Eq` stock instances for `Request` and `Response`
+
+### Changed 
+
+- Function now expect the `ServiceName` type-instances to be defined on `Request` instead of `Response`.
+
+### Removed
+
+N/A
+
 ## [1.0.0] -- 2020-10-23
 
 ### Added

--- a/server/modules/json-wsp/json-wsp.cabal
+++ b/server/modules/json-wsp/json-wsp.cabal
@@ -1,13 +1,13 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 701af22ddfbc925999943f0bb368384a2897cd63ed302baf4558ab6651cad9b3
+-- hash: b4a90f90c64a80a4ad9054bcc058f807aabe032702e9977e027bf8a134410a82
 
 name:           json-wsp
-version:        1.0.0
+version:        1.1.0
 synopsis:       An implementation of JSON-WSP in Haskell
 description:    Please see the README on GitHub at <https://github.com/KtorZ/cardano-ogmios/tree/master/server/modules/json-wsp>
 category:       Web

--- a/server/modules/json-wsp/package.yaml
+++ b/server/modules/json-wsp/package.yaml
@@ -1,7 +1,7 @@
 _config: !include "../../.hpack.config.yaml"
 
 name:                json-wsp
-version:             1.0.0
+version:             1.1.0
 github:              "KtorZ/cardano-ogmios"
 license:             MPL-2.0
 author:              "KtorZ <matthias.benkort@gmail.com>"

--- a/server/modules/json-wsp/src/Codec/Json/Wsp/Handler.hs
+++ b/server/modules/json-wsp/src/Codec/Json/Wsp/Handler.hs
@@ -45,13 +45,13 @@ import qualified Data.Aeson as Json
 --
 -- @since 1.0.0
 data Request a = Request Mirror a
-    deriving (Generic, Show)
+    deriving (Generic, Show, Eq)
 
 -- | Represent a JSON-WSP response (from the server to a client)
 --
 -- @since 1.0.0
 data Response a = Response Mirror a
-    deriving (Generic, Show)
+    deriving (Generic, Show, Eq)
 
 -- | Type alias for the optional mirror(ed) value in Request/Response
 --

--- a/server/src/Ogmios/Data/Protocol.hs
+++ b/server/src/Ogmios/Data/Protocol.hs
@@ -10,6 +10,6 @@ import Ogmios.Prelude
 
 import qualified Codec.Json.Wsp as Wsp
 
-type instance Wsp.ServiceName (Wsp.Response _) = "ogmios"
+type instance Wsp.ServiceName (Wsp.Request _) = "ogmios"
 
 type MethodName = String

--- a/server/src/Ogmios/Data/Protocol/ChainSync.hs
+++ b/server/src/Ogmios/Data/Protocol/ChainSync.hs
@@ -21,6 +21,7 @@ module Ogmios.Data.Protocol.ChainSync
 
       -- ** FindIntersect
     , FindIntersect (..)
+    , _encodeFindIntersect
     , _decodeFindIntersect
     , FindIntersectResponse (..)
     , _encodeFindIntersectResponse
@@ -98,7 +99,18 @@ data ChainSyncMessage block
 
 data FindIntersect block
     = FindIntersect { points :: [Point block] }
-    deriving (Generic, Show)
+    deriving (Generic, Show, Eq)
+
+_encodeFindIntersect
+    :: forall block. ()
+    => (Point block -> Json)
+    -> Wsp.Request (FindIntersect block)
+    -> Json
+_encodeFindIntersect encodePoint =
+    Wsp.mkRequest Wsp.defaultOptions $ \case
+        FindIntersect{points} -> encodeObject
+            [ ( "points", encodeList encodePoint points )
+            ]
 
 _decodeFindIntersect
     :: FromJSON (Point block)

--- a/server/src/Ogmios/Data/Protocol/ChainSync.hs
+++ b/server/src/Ogmios/Data/Protocol/ChainSync.hs
@@ -28,6 +28,7 @@ module Ogmios.Data.Protocol.ChainSync
 
       -- ** RequestNext
     , RequestNext (..)
+    , _encodeRequestNext
     , _decodeRequestNext
     , RequestNextResponse (..)
     , _encodeRequestNextResponse
@@ -154,7 +155,14 @@ _encodeFindIntersectResponse encodePoint encodeTip =
 
 data RequestNext
     = RequestNext
-    deriving (Generic, Show)
+    deriving (Generic, Show, Eq)
+
+_encodeRequestNext
+    :: Wsp.Request RequestNext
+    -> Json
+_encodeRequestNext =
+    Wsp.mkRequest Wsp.defaultOptions $ \case
+        RequestNext -> encodeObject []
 
 _decodeRequestNext
     :: Json.Value

--- a/server/src/Ogmios/Data/Protocol/StateQuery.hs
+++ b/server/src/Ogmios/Data/Protocol/StateQuery.hs
@@ -21,12 +21,14 @@ module Ogmios.Data.Protocol.StateQuery
 
       -- ** Acquire
     , Acquire (..)
+    , _encodeAcquire
     , _decodeAcquire
     , AcquireResponse (..)
     , _encodeAcquireResponse
 
       -- ** Release
     , Release (..)
+    , _encodeRelease
     , _decodeRelease
     , ReleaseResponse (..)
     , _encodeReleaseResponse
@@ -121,7 +123,18 @@ data StateQueryMessage block
 
 data Acquire block
     = Acquire { point :: Point block }
-    deriving (Generic, Show)
+    deriving (Generic, Show, Eq)
+
+_encodeAcquire
+    :: forall block. ()
+    => (Point block -> Json)
+    -> Wsp.Request (Acquire block)
+    -> Json
+_encodeAcquire encodePoint =
+    Wsp.mkRequest Wsp.defaultOptions $ \case
+        Acquire{point} -> encodeObject
+            [ ( "point", encodePoint point )
+            ]
 
 _decodeAcquire
     :: FromJSON (Point block)
@@ -164,7 +177,14 @@ _encodeAcquireResponse encodePoint encodeAcquireFailure =
 
 data Release
     = Release
-    deriving (Generic, Show)
+    deriving (Generic, Show, Eq)
+
+_encodeRelease
+    :: Wsp.Request Release
+    -> Json
+_encodeRelease =
+    Wsp.mkRequest Wsp.defaultOptions $ \case
+        Release -> encodeObject []
 
 _decodeRelease
     :: Json.Value


### PR DESCRIPTION
Fixes #39 

- 7e03e905c1e297414c216009d6614034d2047adf
  :round_pushpin: **Allow constructing WSP request JSON value in json-wsp**
  
- 7a21ba8e4029bbc4927f9eb94f08ef4eb82f5a34
  :round_pushpin: **Add unit test to check JSON schema of arbitrarily generated *FindIntersect* requests**
    There was responses for a while, but not requests.

- bdce31d51f3ac8af58d285e5412095b5a016723c
  :round_pushpin: **Add additional test cases for 'RequestNext', 'Acquire' and 'Release'.**
    It fails, as intended because of #39

- caef7de7e49a1f0e0dfad8a8e8fc949144570822
  :round_pushpin: **Fix wrong schema definition for 'Acquire', now captured by automated tests.**
  
- 86b869a9966b47fad35e1f0d996995ff49ca4b9a
  :round_pushpin: **Fill in CHANGELOG**