### PR TITLE
fix: ensure short-lived message listeners are not removed prematurely

### DIFF
--- a/clients/TypeScript/packages/client/src/StateQuery/Query.ts
+++ b/clients/TypeScript/packages/client/src/StateQuery/Query.ts
@@ -1,0 +1,46 @@
+import { nanoid } from 'nanoid'
+import { Data } from 'isomorphic-ws'
+import { baseRequest } from '../Request'
+import { ensureSocket, InteractionContext } from '../Connection'
+
+export const Query = <
+  Request,
+  QueryResponse extends { reflection?: { requestId?: string } },
+  Response
+  >(
+    request: {
+    methodName: string,
+    args?: any
+  },
+    response: {
+    handler: (
+      response: QueryResponse,
+      resolve: (value?: Response | PromiseLike<Response>) => void,
+      reject: (reason?: any) => void
+    ) => void
+  },
+    context?: InteractionContext
+  ): Promise<Response> =>
+    ensureSocket<Response>((socket) =>
+      new Promise((resolve, reject) => {
+        const requestId = nanoid(5)
+
+        async function listener (data: Data) {
+          const queryResponse = JSON.parse(data as string) as QueryResponse
+          if (queryResponse.reflection?.requestId !== requestId) { return }
+          await response.handler(
+            queryResponse,
+            resolve,
+            reject
+          )
+          socket.removeListener('message', listener)
+        }
+
+        socket.on('message', listener)
+        socket.send(JSON.stringify({
+          ...baseRequest,
+          methodname: request.methodName,
+          args: request.args,
+          mirror: { requestId }
+        } as unknown as Request))
+      }), context)

--- a/clients/TypeScript/packages/client/src/StateQuery/index.ts
+++ b/clients/TypeScript/packages/client/src/StateQuery/index.ts
@@ -1,2 +1,3 @@
 export * from './queries'
+export * from './Query'
 export * from './StateQueryClient'

--- a/clients/TypeScript/packages/client/src/StateQuery/queries/currentEpoch.ts
+++ b/clients/TypeScript/packages/client/src/StateQuery/queries/currentEpoch.ts
@@ -1,41 +1,33 @@
-import { nanoid } from 'nanoid'
 import { Ogmios, Epoch, EraMismatch } from '@cardano-ogmios/schema'
 import { EraMismatchError, QueryUnavailableInCurrentEraError, UnknownResultError } from '../../errors'
-import { baseRequest } from '../../Request'
-import { ensureSocket, InteractionContext } from '../../Connection'
+import { InteractionContext } from '../../Connection'
+import { Query } from '../Query'
 
 const isEraMismatch = (result: Ogmios['QueryResponse[currentEpoch]']['result']): result is EraMismatch =>
   (result as EraMismatch).eraMismatch !== undefined
 
-export const currentEpoch = (context?: InteractionContext): Promise<Epoch> => {
-  return ensureSocket<Epoch>((socket) => {
-    return new Promise((resolve, reject) => {
-      const requestId = nanoid(5)
-      socket.once('message', (message: string) => {
-        const response: Ogmios['QueryResponse[currentEpoch]'] = JSON.parse(message)
-        if (response.reflection.requestId !== requestId) { return }
-        if (response.result === 'QueryUnavailableInCurrentEra') {
-          return reject(new QueryUnavailableInCurrentEraError('currentEpoch'))
-        } else if (typeof response.result === 'number') {
-          return resolve(response.result)
-        } else if (isEraMismatch(response.result)) {
-          const { eraMismatch } = response.result
-          const { ledgerEra, queryEra } = eraMismatch
-          return reject(new EraMismatchError(queryEra, ledgerEra))
-        } else {
-          return reject(new UnknownResultError(response.result))
-        }
-      })
-      socket.send(JSON.stringify({
-        ...baseRequest,
-        methodname: 'Query',
-        args: {
-          query: 'currentEpoch'
-        },
-        mirror: { requestId }
-      } as Ogmios['Query']))
-    })
-  },
-  context
-  )
-}
+export const currentEpoch = (context?: InteractionContext): Promise<Epoch> =>
+  Query<
+    Ogmios['Query'],
+    Ogmios['QueryResponse[currentEpoch]'],
+    Epoch
+  >({
+    methodName: 'Query',
+    args: {
+      query: 'currentEpoch'
+    }
+  }, {
+    handler: (response, resolve, reject) => {
+      if (response.result === 'QueryUnavailableInCurrentEra') {
+        return reject(new QueryUnavailableInCurrentEraError('currentEpoch'))
+      } else if (typeof response.result === 'number') {
+        return resolve(response.result)
+      } else if (isEraMismatch(response.result)) {
+        const { eraMismatch } = response.result
+        const { ledgerEra, queryEra } = eraMismatch
+        return reject(new EraMismatchError(queryEra, ledgerEra))
+      } else {
+        return reject(new UnknownResultError(response.result))
+      }
+    }
+  }, context)

--- a/clients/TypeScript/packages/client/src/StateQuery/queries/currentProtocolParameters.ts
+++ b/clients/TypeScript/packages/client/src/StateQuery/queries/currentProtocolParameters.ts
@@ -1,8 +1,11 @@
-import { nanoid } from 'nanoid'
-import { EraMismatch, Ogmios, ProtocolParametersShelley } from '@cardano-ogmios/schema'
+import {
+  EraMismatch,
+  Ogmios,
+  ProtocolParametersShelley
+} from '@cardano-ogmios/schema'
 import { EraMismatchError, QueryUnavailableInCurrentEraError, UnknownResultError } from '../../errors'
-import { baseRequest } from '../../Request'
-import { ensureSocket, InteractionContext } from '../../Connection'
+import { InteractionContext } from '../../Connection'
+import { Query } from '../Query'
 
 const isEraMismatch = (result: Ogmios['QueryResponse[currentProtocolParameters]']['result']): result is EraMismatch =>
   (result as EraMismatch).eraMismatch !== undefined
@@ -10,35 +13,29 @@ const isEraMismatch = (result: Ogmios['QueryResponse[currentProtocolParameters]'
 const isProtocolParameters = (result: Ogmios['QueryResponse[currentProtocolParameters]']['result']): result is ProtocolParametersShelley =>
   (result as ProtocolParametersShelley).minFeeCoefficient !== undefined
 
-export const currentProtocolParameters = (context?: InteractionContext): Promise<ProtocolParametersShelley> => {
-  return ensureSocket<ProtocolParametersShelley>((socket) => {
-    return new Promise((resolve, reject) => {
-      const requestId = nanoid(5)
-      socket.once('message', (message: string) => {
-        const response: Ogmios['QueryResponse[currentProtocolParameters]'] = JSON.parse(message)
-        if (response.reflection.requestId !== requestId) { return }
-        if (response.result === 'QueryUnavailableInCurrentEra') {
-          return reject(new QueryUnavailableInCurrentEraError('currentProtocolParameters'))
-        } else if (isProtocolParameters(response.result)) {
-          return resolve(response.result)
-        } else if (isEraMismatch(response.result)) {
-          const { eraMismatch } = response.result
-          const { ledgerEra, queryEra } = eraMismatch
-          return reject(new EraMismatchError(queryEra, ledgerEra))
-        } else {
-          return reject(new UnknownResultError(response.result))
-        }
-      })
-      socket.send(JSON.stringify({
-        ...baseRequest,
-        methodname: 'Query',
-        args: {
-          query: 'currentProtocolParameters'
-        },
-        mirror: { requestId }
-      } as Ogmios['Query']))
-    })
+export const currentProtocolParameters = (context?: InteractionContext): Promise<ProtocolParametersShelley> =>
+  Query<
+    Ogmios['Query'],
+    Ogmios['QueryResponse[currentProtocolParameters]'],
+    ProtocolParametersShelley
+  >({
+    methodName: 'Query',
+    args: {
+      query: 'currentProtocolParameters'
+    }
+  }, {
+    handler: (response, resolve, reject) => {
+      if (response.result === 'QueryUnavailableInCurrentEra') {
+        return reject(new QueryUnavailableInCurrentEraError('currentProtocolParameters'))
+      } else if (isProtocolParameters(response.result)) {
+        return resolve(response.result)
+      } else if (isEraMismatch(response.result)) {
+        const { eraMismatch } = response.result
+        const { ledgerEra, queryEra } = eraMismatch
+        return reject(new EraMismatchError(queryEra, ledgerEra))
+      } else {
+        return reject(new UnknownResultError(response.result))
+      }
+    }
   },
-  context
-  )
-}
+  context)

--- a/clients/TypeScript/packages/client/src/StateQuery/queries/delegationsAndRewards.ts
+++ b/clients/TypeScript/packages/client/src/StateQuery/queries/delegationsAndRewards.ts
@@ -1,12 +1,11 @@
-import { nanoid } from 'nanoid'
 import {
   DelegationsAndRewards1,
   EraMismatch, Hash16,
   Ogmios
 } from '@cardano-ogmios/schema'
 import { EraMismatchError, QueryUnavailableInCurrentEraError, UnknownResultError } from '../../errors'
-import { baseRequest } from '../../Request'
-import { ensureSocket, InteractionContext } from '../../Connection'
+import { InteractionContext } from '../../Connection'
+import { Query } from '../Query'
 
 const isEraMismatch = (result: Ogmios['QueryResponse[delegationsAndRewards]']['result']): result is EraMismatch =>
   (result as EraMismatch).eraMismatch !== undefined
@@ -16,35 +15,28 @@ const isDelegationsAndRewards = (result: Ogmios['QueryResponse[delegationsAndRew
   return typeof sample[0] === 'string' && (sample[1].delegate !== undefined || sample[1].rewards !== undefined)
 }
 
-export const delegationsAndRewards = (stakeKeyHashes: Hash16[], context?: InteractionContext): Promise<DelegationsAndRewards1> => {
-  return ensureSocket<DelegationsAndRewards1>((socket) => {
-    return new Promise((resolve, reject) => {
-      const requestId = nanoid(5)
-      socket.once('message', (message: string) => {
-        const response: Ogmios['QueryResponse[delegationsAndRewards]'] = JSON.parse(message)
-        if (response.reflection.requestId !== requestId) { return }
-        if (response.result === 'QueryUnavailableInCurrentEra') {
-          return reject(new QueryUnavailableInCurrentEraError('delegationsAndRewards'))
-        } else if (isEraMismatch(response.result)) {
-          const { eraMismatch } = response.result
-          const { ledgerEra, queryEra } = eraMismatch
-          return reject(new EraMismatchError(queryEra, ledgerEra))
-        } else if (isDelegationsAndRewards(response.result)) {
-          return resolve(response.result)
-        } else {
-          return reject(new UnknownResultError(response.result))
-        }
-      })
-      socket.send(JSON.stringify({
-        ...baseRequest,
-        methodname: 'Query',
-        args: {
-          query: { delegationsAndRewards: stakeKeyHashes }
-        },
-        mirror: { requestId }
-      } as Ogmios['Query']))
-    })
-  },
-  context
-  )
-}
+export const delegationsAndRewards = (stakeKeyHashes: Hash16[], context?: InteractionContext): Promise<DelegationsAndRewards1> =>
+  Query<
+    Ogmios['Query'],
+    Ogmios['QueryResponse[delegationsAndRewards]'],
+    DelegationsAndRewards1
+  >({
+    methodName: 'Query',
+    args: {
+      query: { delegationsAndRewards: stakeKeyHashes }
+    }
+  }, {
+    handler: (response, resolve, reject) => {
+      if (response.result === 'QueryUnavailableInCurrentEra') {
+        return reject(new QueryUnavailableInCurrentEraError('delegationsAndRewards'))
+      } else if (isEraMismatch(response.result)) {
+        const { eraMismatch } = response.result
+        const { ledgerEra, queryEra } = eraMismatch
+        return reject(new EraMismatchError(queryEra, ledgerEra))
+      } else if (isDelegationsAndRewards(response.result)) {
+        return resolve(response.result)
+      } else {
+        return reject(new UnknownResultError(response.result))
+      }
+    }
+  }, context)

--- a/clients/TypeScript/packages/client/src/StateQuery/queries/eraStart.ts
+++ b/clients/TypeScript/packages/client/src/StateQuery/queries/eraStart.ts
@@ -1,39 +1,31 @@
-import { nanoid } from 'nanoid'
 import { Ogmios, Bound } from '@cardano-ogmios/schema'
 import { QueryUnavailableInCurrentEraError, UnknownResultError } from '../../errors'
-import { baseRequest } from '../../Request'
-import { ensureSocket, InteractionContext } from '../../Connection'
+import { InteractionContext } from '../../Connection'
+import { Query } from '../Query'
 
 const isBound = (result: Ogmios['QueryResponse[eraStart]']['result']): result is Bound => {
   const bound = result as Bound
   return bound.time !== undefined && bound.slot !== undefined && bound.epoch !== undefined
 }
 
-export const eraStart = (context?: InteractionContext): Promise<Bound> => {
-  return ensureSocket<Bound>((socket) => {
-    return new Promise((resolve, reject) => {
-      const requestId = nanoid(5)
-      socket.once('message', (message: string) => {
-        const response: Ogmios['QueryResponse[eraStart]'] = JSON.parse(message)
-        if (response.reflection.requestId !== requestId) { return }
-        if (response.result === 'QueryUnavailableInCurrentEra') {
-          return reject(new QueryUnavailableInCurrentEraError('ledgerTip'))
-        } else if (isBound(response.result)) {
-          return resolve(response.result)
-        } else {
-          return reject(new UnknownResultError(response.result))
-        }
-      })
-      socket.send(JSON.stringify({
-        ...baseRequest,
-        methodname: 'Query',
-        args: {
-          query: 'eraStart'
-        },
-        mirror: { requestId }
-      } as Ogmios['Query']))
-    })
-  },
-  context
-  )
-}
+export const eraStart = (context?: InteractionContext): Promise<Bound> =>
+  Query<
+    Ogmios['Query'],
+    Ogmios['QueryResponse[eraStart]'],
+    Bound
+  >({
+    methodName: 'Query',
+    args: {
+      query: 'eraStart'
+    }
+  }, {
+    handler: (response, resolve, reject) => {
+      if (response.result === 'QueryUnavailableInCurrentEra') {
+        return reject(new QueryUnavailableInCurrentEraError('ledgerTip'))
+      } else if (isBound(response.result)) {
+        return resolve(response.result)
+      } else {
+        return reject(new UnknownResultError(response.result))
+      }
+    }
+  }, context)

--- a/clients/TypeScript/packages/client/src/StateQuery/queries/genesisConfig.ts
+++ b/clients/TypeScript/packages/client/src/StateQuery/queries/genesisConfig.ts
@@ -1,8 +1,7 @@
-import { nanoid } from 'nanoid'
 import { CompactGenesis, EraMismatch, Ogmios } from '@cardano-ogmios/schema'
 import { EraMismatchError, QueryUnavailableInCurrentEraError, UnknownResultError } from '../../errors'
-import { baseRequest } from '../../Request'
-import { ensureSocket, InteractionContext } from '../../Connection'
+import { InteractionContext } from '../../Connection'
+import { Query } from '../Query'
 
 const isEraMismatch = (result: Ogmios['QueryResponse[currentProtocolParameters]']['result']): result is EraMismatch =>
   (result as EraMismatch).eraMismatch !== undefined
@@ -10,35 +9,28 @@ const isEraMismatch = (result: Ogmios['QueryResponse[currentProtocolParameters]'
 const isGenesisConfig = (result: Ogmios['QueryResponse[genesisConfig]']['result']): result is CompactGenesis =>
   (result as CompactGenesis).systemStart !== undefined
 
-export const genesisConfig = (context?: InteractionContext): Promise<CompactGenesis> => {
-  return ensureSocket<CompactGenesis>((socket) => {
-    return new Promise((resolve, reject) => {
-      const requestId = nanoid(5)
-      socket.once('message', (message: string) => {
-        const response: Ogmios['QueryResponse[genesisConfig]'] = JSON.parse(message)
-        if (response.reflection.requestId !== requestId) { return }
-        if (response.result === 'QueryUnavailableInCurrentEra') {
-          return reject(new QueryUnavailableInCurrentEraError('genesisConfig'))
-        } else if (isGenesisConfig(response.result)) {
-          return resolve(response.result)
-        } else if (isEraMismatch(response.result)) {
-          const { eraMismatch } = response.result
-          const { ledgerEra, queryEra } = eraMismatch
-          return reject(new EraMismatchError(queryEra, ledgerEra))
-        } else {
-          return reject(new UnknownResultError(response.result))
-        }
-      })
-      socket.send(JSON.stringify({
-        ...baseRequest,
-        methodname: 'Query',
-        args: {
-          query: 'genesisConfig'
-        },
-        mirror: { requestId }
-      } as Ogmios['Query']))
-    })
-  },
-  context
-  )
-}
+export const genesisConfig = (context?: InteractionContext): Promise<CompactGenesis> =>
+  Query<
+    Ogmios['Query'],
+    Ogmios['QueryResponse[genesisConfig]'],
+    CompactGenesis
+  >({
+    methodName: 'Query',
+    args: {
+      query: 'genesisConfig'
+    }
+  }, {
+    handler: (response, resolve, reject) => {
+      if (response.result === 'QueryUnavailableInCurrentEra') {
+        return reject(new QueryUnavailableInCurrentEraError('genesisConfig'))
+      } else if (isGenesisConfig(response.result)) {
+        return resolve(response.result)
+      } else if (isEraMismatch(response.result)) {
+        const { eraMismatch } = response.result
+        const { ledgerEra, queryEra } = eraMismatch
+        return reject(new EraMismatchError(queryEra, ledgerEra))
+      } else {
+        return reject(new UnknownResultError(response.result))
+      }
+    }
+  }, context)

--- a/clients/TypeScript/packages/client/src/StateQuery/queries/ledgerTip.ts
+++ b/clients/TypeScript/packages/client/src/StateQuery/queries/ledgerTip.ts
@@ -1,8 +1,7 @@
-import { nanoid } from 'nanoid'
 import { EraMismatch, Hash16, Ogmios, Point, Slot } from '@cardano-ogmios/schema'
 import { EraMismatchError, QueryUnavailableInCurrentEraError, UnknownResultError } from '../../errors'
-import { baseRequest } from '../../Request'
-import { ensureSocket, InteractionContext } from '../../Connection'
+import { InteractionContext } from '../../Connection'
+import { Query } from '../Query'
 
 const isEraMismatch = (result: Ogmios['QueryResponse[ledgerTip]']['result']): result is EraMismatch =>
   (result as EraMismatch).eraMismatch !== undefined
@@ -10,37 +9,30 @@ const isEraMismatch = (result: Ogmios['QueryResponse[ledgerTip]']['result']): re
 const isNonOriginPoint = (result: {slot: Slot, hash: Hash16}): result is {slot: Slot, hash: Hash16} =>
   (result as {slot: Slot, hash: Hash16}).slot !== undefined
 
-export const ledgerTip = (context?: InteractionContext): Promise<Point> => {
-  return ensureSocket<Point>((socket) => {
-    return new Promise((resolve, reject) => {
-      const requestId = nanoid(5)
-      socket.once('message', (message: string) => {
-        const response: Ogmios['QueryResponse[ledgerTip]'] = JSON.parse(message)
-        if (response.reflection.requestId !== requestId) { return }
-        if (response.result === 'QueryUnavailableInCurrentEra') {
-          return reject(new QueryUnavailableInCurrentEraError('ledgerTip'))
-        } else if (response.result === 'origin') {
-          return resolve(response.result)
-        } else if (isEraMismatch(response.result)) {
-          const { eraMismatch } = response.result
-          const { ledgerEra, queryEra } = eraMismatch
-          return reject(new EraMismatchError(queryEra, ledgerEra))
-        } else if (isNonOriginPoint(response.result)) {
-          return resolve(response.result)
-        } else {
-          return reject(new UnknownResultError(response.result))
-        }
-      })
-      socket.send(JSON.stringify({
-        ...baseRequest,
-        methodname: 'Query',
-        args: {
-          query: 'ledgerTip'
-        },
-        mirror: { requestId }
-      } as Ogmios['Query']))
-    })
-  },
-  context
-  )
-}
+export const ledgerTip = (context?: InteractionContext): Promise<Point> =>
+  Query<
+    Ogmios['Query'],
+    Ogmios['QueryResponse[ledgerTip]'],
+    Point
+  >({
+    methodName: 'Query',
+    args: {
+      query: 'ledgerTip'
+    }
+  }, {
+    handler: (response, resolve, reject) => {
+      if (response.result === 'QueryUnavailableInCurrentEra') {
+        return reject(new QueryUnavailableInCurrentEraError('ledgerTip'))
+      } else if (response.result === 'origin') {
+        resolve(response.result)
+      } else if (isEraMismatch(response.result)) {
+        const { eraMismatch } = response.result
+        const { ledgerEra, queryEra } = eraMismatch
+        reject(new EraMismatchError(queryEra, ledgerEra))
+      } else if (isNonOriginPoint(response.result)) {
+        return resolve(response.result)
+      } else {
+        reject(new UnknownResultError(response.result))
+      }
+    }
+  }, context)

--- a/clients/TypeScript/packages/client/src/StateQuery/queries/nonMyopicMemberRewards.ts
+++ b/clients/TypeScript/packages/client/src/StateQuery/queries/nonMyopicMemberRewards.ts
@@ -1,8 +1,13 @@
-import { nanoid } from 'nanoid'
-import { EraMismatch, Hash16, Lovelace, NonMyopicMemberRewards1, Ogmios } from '@cardano-ogmios/schema'
+import {
+  EraMismatch,
+  Hash16,
+  Lovelace,
+  NonMyopicMemberRewards1,
+  Ogmios
+} from '@cardano-ogmios/schema'
 import { EraMismatchError, QueryUnavailableInCurrentEraError, UnknownResultError } from '../../errors'
-import { baseRequest } from '../../Request'
-import { ensureSocket, InteractionContext } from '../../Connection'
+import { InteractionContext } from '../../Connection'
+import { Query } from '../Query'
 
 const isEraMismatch = (result: Ogmios['QueryResponse[nonMyopicMemberRewards]']['result']): result is EraMismatch =>
   (result as EraMismatch).eraMismatch !== undefined
@@ -12,37 +17,30 @@ const isNonMyopicMemberRewards = (result: Ogmios['QueryResponse[nonMyopicMemberR
     Object.values(result as NonMyopicMemberRewards1)[0]
   )[0] === 'number'
 
-export const nonMyopicMemberRewards = (input: (Lovelace | Hash16)[], context?: InteractionContext): Promise<NonMyopicMemberRewards1> => {
-  return ensureSocket<NonMyopicMemberRewards1>((socket) => {
-    return new Promise((resolve, reject) => {
-      const requestId = nanoid(5)
-      socket.once('message', (message: string) => {
-        const response: Ogmios['QueryResponse[nonMyopicMemberRewards]'] = JSON.parse(message)
-        if (response.reflection.requestId !== requestId) { return }
-        if (response.result === 'QueryUnavailableInCurrentEra') {
-          return reject(new QueryUnavailableInCurrentEraError('nonMyopicMemberRewards'))
-        } else if (isNonMyopicMemberRewards(response.result)) {
-          return resolve(response.result)
-        } else if (isEraMismatch(response.result)) {
-          const { eraMismatch } = response.result
-          const { ledgerEra, queryEra } = eraMismatch
-          return reject(new EraMismatchError(queryEra, ledgerEra))
-        } else {
-          return reject(new UnknownResultError(response.result))
-        }
-      })
-      socket.send(JSON.stringify({
-        ...baseRequest,
-        methodname: 'Query',
-        args: {
-          query: {
-            nonMyopicMemberRewards: input
-          }
-        },
-        mirror: { requestId }
-      } as Ogmios['Query']))
-    })
-  },
-  context
-  )
-}
+export const nonMyopicMemberRewards = (input: (Lovelace | Hash16)[], context?: InteractionContext): Promise<NonMyopicMemberRewards1> =>
+  Query<
+    Ogmios['Query'],
+    Ogmios['QueryResponse[nonMyopicMemberRewards]'],
+    NonMyopicMemberRewards1
+  >({
+    methodName: 'Query',
+    args: {
+      query: {
+        nonMyopicMemberRewards: input
+      }
+    }
+  }, {
+    handler: (response, resolve, reject) => {
+      if (response.result === 'QueryUnavailableInCurrentEra') {
+        return reject(new QueryUnavailableInCurrentEraError('nonMyopicMemberRewards'))
+      } else if (isNonMyopicMemberRewards(response.result)) {
+        return resolve(response.result)
+      } else if (isEraMismatch(response.result)) {
+        const { eraMismatch } = response.result
+        const { ledgerEra, queryEra } = eraMismatch
+        return reject(new EraMismatchError(queryEra, ledgerEra))
+      } else {
+        return reject(new UnknownResultError(response.result))
+      }
+    }
+  }, context)

--- a/clients/TypeScript/packages/client/src/StateQuery/queries/proposedProtocolParameters.ts
+++ b/clients/TypeScript/packages/client/src/StateQuery/queries/proposedProtocolParameters.ts
@@ -1,9 +1,8 @@
-import { nanoid } from 'nanoid'
 import { EraMismatch, Ogmios, ProtocolParametersShelley } from '@cardano-ogmios/schema'
 import { EraMismatchError, QueryUnavailableInCurrentEraError } from '../../errors'
-import { baseRequest } from '../../Request'
-import { ensureSocket, InteractionContext } from '../../Connection'
+import { InteractionContext } from '../../Connection'
 import { isEmptyObject } from '../../util'
+import { Query } from '../Query'
 
 export interface ObjectOfProtocolParametersShelley { [k: string]: ProtocolParametersShelley }
 
@@ -13,37 +12,30 @@ const isEraMismatch = (result: Ogmios['QueryResponse[proposedProtocolParameters]
 const isObjectOfProtocolParametersShelley = (result: Ogmios['QueryResponse[proposedProtocolParameters]']['result']): result is ObjectOfProtocolParametersShelley =>
   Object.values(result as ObjectOfProtocolParametersShelley)[0]?.minFeeCoefficient !== undefined
 
-export const proposedProtocolParameters = (context?: InteractionContext): Promise<ObjectOfProtocolParametersShelley | null> => {
-  return ensureSocket<{[k: string]: ProtocolParametersShelley}>((socket) => {
-    return new Promise((resolve, reject) => {
-      const requestId = nanoid(5)
-      socket.once('message', (message: string) => {
-        const response: Ogmios['QueryResponse[proposedProtocolParameters]'] = JSON.parse(message)
-        if (response.reflection.requestId !== requestId) { return }
-        if (isEmptyObject(response.result)) {
-          resolve(null)
-        } else if (response.result === 'QueryUnavailableInCurrentEra') {
-          return reject(new QueryUnavailableInCurrentEraError('proposedProtocolParameters'))
-        } else if (isObjectOfProtocolParametersShelley(response.result)) {
-          return resolve(response.result)
-        } else if (isEraMismatch(response.result)) {
-          const { eraMismatch } = response.result
-          const { ledgerEra, queryEra } = eraMismatch
-          return reject(new EraMismatchError(queryEra, ledgerEra))
-        } else {
-          return resolve(response.result)
-        }
-      })
-      socket.send(JSON.stringify({
-        ...baseRequest,
-        methodname: 'Query',
-        args: {
-          query: 'proposedProtocolParameters'
-        },
-        mirror: { requestId }
-      } as Ogmios['Query']))
-    })
-  },
-  context
-  )
-}
+export const proposedProtocolParameters = (context?: InteractionContext): Promise<ObjectOfProtocolParametersShelley | null> =>
+  Query<
+    Ogmios['Query'],
+    Ogmios['QueryResponse[proposedProtocolParameters]'],
+    ObjectOfProtocolParametersShelley | null
+  >({
+    methodName: 'Query',
+    args: {
+      query: 'proposedProtocolParameters'
+    }
+  }, {
+    handler: (response, resolve, reject) => {
+      if (isEmptyObject(response.result)) {
+        resolve(null)
+      } else if (response.result === 'QueryUnavailableInCurrentEra') {
+        return reject(new QueryUnavailableInCurrentEraError('proposedProtocolParameters'))
+      } else if (isObjectOfProtocolParametersShelley(response.result)) {
+        return resolve(response.result)
+      } else if (isEraMismatch(response.result)) {
+        const { eraMismatch } = response.result
+        const { ledgerEra, queryEra } = eraMismatch
+        return reject(new EraMismatchError(queryEra, ledgerEra))
+      } else {
+        return resolve(response.result)
+      }
+    }
+  }, context)

--- a/clients/TypeScript/packages/client/src/TxSubmission/submitTx.ts
+++ b/clients/TypeScript/packages/client/src/TxSubmission/submitTx.ts
@@ -1,133 +1,125 @@
-import { nanoid } from 'nanoid'
-import { ensureSocket, InteractionContext } from '../Connection'
+import { InteractionContext } from '../Connection'
 import { EraMismatchError, UnknownResultError } from '../errors'
 import { errors } from './errors'
-import { baseRequest } from '../Request'
 import { EraMismatch, Ogmios, SubmitFail } from '@cardano-ogmios/schema'
+import { Query } from '../StateQuery'
 
 const isEraMismatch = (item: SubmitFail['SubmitFail']): item is EraMismatch =>
   (item as EraMismatch).eraMismatch !== undefined
 
-export const submitTx = (bytes: string, context?: InteractionContext) => {
-  return ensureSocket<void>((socket) => {
-    return new Promise((resolve, reject) => {
-      const requestId = nanoid(5)
-      socket.once('message', (message) => {
-        const response: Ogmios['SubmitTxResponse'] = JSON.parse(message)
-        if (response.reflection.requestId !== requestId) { return }
-        if (response.methodname === 'SubmitTx') {
-          const { result } = response
-          if (result === 'SubmitSuccess') {
-            return resolve()
-          } else if ('SubmitFail' in result) {
-            const { SubmitFail } = result
-            if (isEraMismatch(SubmitFail)) {
-              const { eraMismatch } = SubmitFail
-              return reject(new EraMismatchError(eraMismatch.queryEra, eraMismatch.ledgerEra))
-            } else if (errors.byron.UtxoValidation.assert(SubmitFail)) {
-              return reject(new errors.byron.UtxoValidation.Error(SubmitFail))
-            } else if (errors.byron.TxValidation.assert(SubmitFail)) {
-              return reject(new errors.byron.TxValidation.Error(SubmitFail))
-            } else if (Array.isArray(SubmitFail)) {
-              reject(SubmitFail.map(failure => {
-                if (errors.shelley.InvalidWitnesses.assert(failure)) {
-                  return new errors.shelley.InvalidWitnesses.Error(failure)
-                } else if (errors.shelley.MissingVkWitnesses.assert(failure)) {
-                  return new errors.shelley.MissingVkWitnesses.Error(failure)
-                } else if (errors.shelley.MissingScriptWitnesses.assert(failure)) {
-                  return new errors.shelley.MissingScriptWitnesses.Error(failure)
-                } else if (errors.shelley.ScriptWitnessNotValidating.assert(failure)) {
-                  return new errors.shelley.ScriptWitnessNotValidating.Error(failure)
-                } else if (errors.shelley.InsufficientGenesisSignatures.assert(failure)) {
-                  return new errors.shelley.InsufficientGenesisSignatures.Error(failure)
-                } else if (errors.shelley.MissingTxMetadata.assert(failure)) {
-                  return new errors.shelley.MissingTxMetadata.Error(failure)
-                } else if (errors.shelley.MissingTxMetadataHash.assert(failure)) {
-                  return new errors.shelley.MissingTxMetadataHash.Error(failure)
-                } else if (errors.shelley.TxMetadataHashMismatch.assert(failure)) {
-                  return new errors.shelley.TxMetadataHashMismatch.Error(failure)
-                } else if (errors.shelley.BadInputs.assert(failure)) {
-                  return new errors.shelley.BadInputs.Error(failure)
-                } else if (errors.shelley.ExpiredUtxo.assert(failure)) {
-                  return new errors.shelley.ExpiredUtxo.Error(failure)
-                } else if (errors.shelley.TxTooLarge.assert(failure)) {
-                  return new errors.shelley.TxTooLarge.Error(failure)
-                } else if (errors.shelley.MissingAtLeastOneInputUtxo.assert(failure)) {
-                  return new errors.shelley.MissingAtLeastOneInputUtxo.Error(failure)
-                } else if (errors.shelley.InvalidMetadata.assert(failure)) {
-                  return new errors.shelley.InvalidMetadata.Error(failure)
-                } else if (errors.shelley.FeeTooSmall.assert(failure)) {
-                  return new errors.shelley.FeeTooSmall.Error(failure)
-                } else if (errors.shelley.ValueNotConserved.assert(failure)) {
-                  return new errors.shelley.ValueNotConserved.Error(failure)
-                } else if (errors.shelley.NetworkMismatch.assert(failure)) {
-                  return new errors.shelley.NetworkMismatch.Error(failure)
-                } else if (errors.shelley.OutputTooSmall.assert(failure)) {
-                  return new errors.shelley.OutputTooSmall.Error(failure)
-                } else if (errors.shelley.AddressAttributesTooLarge.assert(failure)) {
-                  return new errors.shelley.AddressAttributesTooLarge.Error(failure)
-                } else if (errors.shelley.DelegateNotRegistered.assert(failure)) {
-                  return new errors.shelley.DelegateNotRegistered.Error(failure)
-                } else if (errors.shelley.UnknownOrIncompleteWithdrawals.assert(failure)) {
-                  return new errors.shelley.UnknownOrIncompleteWithdrawals.Error(failure)
-                } else if (errors.shelley.StakePoolNotRegistered.assert(failure)) {
-                  return new errors.shelley.StakePoolNotRegistered.Error(failure)
-                } else if (errors.shelley.WrongRetirementEpoch.assert(failure)) {
-                  return new errors.shelley.WrongRetirementEpoch.Error(failure)
-                } else if (errors.shelley.WrongPoolCertificate.assert(failure)) {
-                  return new errors.shelley.WrongPoolCertificate.Error(failure)
-                } else if (errors.shelley.StakeKeyAlreadyRegistered.assert(failure)) {
-                  return new errors.shelley.StakeKeyAlreadyRegistered.Error(failure)
-                } else if (errors.shelley.PoolCostTooSmall.assert(failure)) {
-                  return new errors.shelley.PoolCostTooSmall.Error(failure)
-                } else if (errors.shelley.StakeKeyNotRegistered.assert(failure)) {
-                  return new errors.shelley.StakeKeyNotRegistered.Error(failure)
-                } else if (errors.shelley.RewardAccountNotExisting.assert(failure)) {
-                  return new errors.shelley.RewardAccountNotExisting.Error(failure)
-                } else if (errors.shelley.RewardAccountNotEmpty.assert(failure)) {
-                  return new errors.shelley.RewardAccountNotEmpty.Error(failure)
-                } else if (errors.shelley.WrongCertificateType.assert(failure)) {
-                  return new errors.shelley.WrongCertificateType.Error(failure)
-                } else if (errors.shelley.UnknownGenesisKey.assert(failure)) {
-                  return new errors.shelley.UnknownGenesisKey.Error(failure)
-                } else if (errors.shelley.AlreadyDelegating.assert(failure)) {
-                  return new errors.shelley.AlreadyDelegating.Error(failure)
-                } else if (errors.shelley.InsufficientFundsForMir.assert(failure)) {
-                  return new errors.shelley.InsufficientFundsForMir.Error(failure)
-                } else if (errors.shelley.TooLateForMir.assert(failure)) {
-                  return new errors.shelley.TooLateForMir.Error(failure)
-                } else if (errors.shelley.DuplicateGenesisVrf.assert(failure)) {
-                  return new errors.shelley.DuplicateGenesisVrf.Error(failure)
-                } else if (errors.shelley.NonGenesisVoters.assert(failure)) {
-                  return new errors.shelley.NonGenesisVoters.Error(failure)
-                } else if (errors.shelley.UpdateWrongEpoch.assert(failure)) {
-                  return new errors.shelley.UpdateWrongEpoch.Error(failure)
-                } else if (errors.shelley.ProtocolVersionCannotFollow.assert(failure)) {
-                  return new errors.shelley.ProtocolVersionCannotFollow.Error(failure)
-                } else if (errors.shelley.OutsideOfValidityInterval.assert(failure)) {
-                  return new errors.shelley.OutsideOfValidityInterval.Error(failure)
-                } else if (errors.shelley.TriesToForgeAda.assert(failure)) {
-                  return new errors.shelley.TriesToForgeAda.Error(failure)
-                } else if (errors.shelley.TooManyAssetsInOutput.assert(failure)) {
-                  return new errors.shelley.TooManyAssetsInOutput.Error(failure)
-                } else {
-                  return new Error(failure)
-                }
-              }))
-            }
+export const submitTx = (bytes: string, context?: InteractionContext) =>
+  Query<
+    Ogmios['SubmitTx'],
+    Ogmios['SubmitTxResponse'],
+    void
+  >({
+    methodName: 'SubmitTx',
+    args: { bytes }
+  }, {
+    handler: (response, resolve, reject) => {
+      if (response.methodname === 'SubmitTx') {
+        const { result } = response
+        if (result === 'SubmitSuccess') {
+          return resolve()
+        } else if ('SubmitFail' in result) {
+          const { SubmitFail } = result
+          if (isEraMismatch(SubmitFail)) {
+            const { eraMismatch } = SubmitFail
+            return reject(new EraMismatchError(eraMismatch.queryEra, eraMismatch.ledgerEra))
+          } else if (errors.byron.UtxoValidation.assert(SubmitFail)) {
+            return reject(new errors.byron.UtxoValidation.Error(SubmitFail))
+          } else if (errors.byron.TxValidation.assert(SubmitFail)) {
+            return reject(new errors.byron.TxValidation.Error(SubmitFail))
+          } else if (Array.isArray(SubmitFail)) {
+            reject(SubmitFail.map(failure => {
+              if (errors.shelley.InvalidWitnesses.assert(failure)) {
+                return new errors.shelley.InvalidWitnesses.Error(failure)
+              } else if (errors.shelley.MissingVkWitnesses.assert(failure)) {
+                return new errors.shelley.MissingVkWitnesses.Error(failure)
+              } else if (errors.shelley.MissingScriptWitnesses.assert(failure)) {
+                return new errors.shelley.MissingScriptWitnesses.Error(failure)
+              } else if (errors.shelley.ScriptWitnessNotValidating.assert(failure)) {
+                return new errors.shelley.ScriptWitnessNotValidating.Error(failure)
+              } else if (errors.shelley.InsufficientGenesisSignatures.assert(failure)) {
+                return new errors.shelley.InsufficientGenesisSignatures.Error(failure)
+              } else if (errors.shelley.MissingTxMetadata.assert(failure)) {
+                return new errors.shelley.MissingTxMetadata.Error(failure)
+              } else if (errors.shelley.MissingTxMetadataHash.assert(failure)) {
+                return new errors.shelley.MissingTxMetadataHash.Error(failure)
+              } else if (errors.shelley.TxMetadataHashMismatch.assert(failure)) {
+                return new errors.shelley.TxMetadataHashMismatch.Error(failure)
+              } else if (errors.shelley.BadInputs.assert(failure)) {
+                return new errors.shelley.BadInputs.Error(failure)
+              } else if (errors.shelley.ExpiredUtxo.assert(failure)) {
+                return new errors.shelley.ExpiredUtxo.Error(failure)
+              } else if (errors.shelley.TxTooLarge.assert(failure)) {
+                return new errors.shelley.TxTooLarge.Error(failure)
+              } else if (errors.shelley.MissingAtLeastOneInputUtxo.assert(failure)) {
+                return new errors.shelley.MissingAtLeastOneInputUtxo.Error(failure)
+              } else if (errors.shelley.InvalidMetadata.assert(failure)) {
+                return new errors.shelley.InvalidMetadata.Error(failure)
+              } else if (errors.shelley.FeeTooSmall.assert(failure)) {
+                return new errors.shelley.FeeTooSmall.Error(failure)
+              } else if (errors.shelley.ValueNotConserved.assert(failure)) {
+                return new errors.shelley.ValueNotConserved.Error(failure)
+              } else if (errors.shelley.NetworkMismatch.assert(failure)) {
+                return new errors.shelley.NetworkMismatch.Error(failure)
+              } else if (errors.shelley.OutputTooSmall.assert(failure)) {
+                return new errors.shelley.OutputTooSmall.Error(failure)
+              } else if (errors.shelley.AddressAttributesTooLarge.assert(failure)) {
+                return new errors.shelley.AddressAttributesTooLarge.Error(failure)
+              } else if (errors.shelley.DelegateNotRegistered.assert(failure)) {
+                return new errors.shelley.DelegateNotRegistered.Error(failure)
+              } else if (errors.shelley.UnknownOrIncompleteWithdrawals.assert(failure)) {
+                return new errors.shelley.UnknownOrIncompleteWithdrawals.Error(failure)
+              } else if (errors.shelley.StakePoolNotRegistered.assert(failure)) {
+                return new errors.shelley.StakePoolNotRegistered.Error(failure)
+              } else if (errors.shelley.WrongRetirementEpoch.assert(failure)) {
+                return new errors.shelley.WrongRetirementEpoch.Error(failure)
+              } else if (errors.shelley.WrongPoolCertificate.assert(failure)) {
+                return new errors.shelley.WrongPoolCertificate.Error(failure)
+              } else if (errors.shelley.StakeKeyAlreadyRegistered.assert(failure)) {
+                return new errors.shelley.StakeKeyAlreadyRegistered.Error(failure)
+              } else if (errors.shelley.PoolCostTooSmall.assert(failure)) {
+                return new errors.shelley.PoolCostTooSmall.Error(failure)
+              } else if (errors.shelley.StakeKeyNotRegistered.assert(failure)) {
+                return new errors.shelley.StakeKeyNotRegistered.Error(failure)
+              } else if (errors.shelley.RewardAccountNotExisting.assert(failure)) {
+                return new errors.shelley.RewardAccountNotExisting.Error(failure)
+              } else if (errors.shelley.RewardAccountNotEmpty.assert(failure)) {
+                return new errors.shelley.RewardAccountNotEmpty.Error(failure)
+              } else if (errors.shelley.WrongCertificateType.assert(failure)) {
+                return new errors.shelley.WrongCertificateType.Error(failure)
+              } else if (errors.shelley.UnknownGenesisKey.assert(failure)) {
+                return new errors.shelley.UnknownGenesisKey.Error(failure)
+              } else if (errors.shelley.AlreadyDelegating.assert(failure)) {
+                return new errors.shelley.AlreadyDelegating.Error(failure)
+              } else if (errors.shelley.InsufficientFundsForMir.assert(failure)) {
+                return new errors.shelley.InsufficientFundsForMir.Error(failure)
+              } else if (errors.shelley.TooLateForMir.assert(failure)) {
+                return new errors.shelley.TooLateForMir.Error(failure)
+              } else if (errors.shelley.DuplicateGenesisVrf.assert(failure)) {
+                return new errors.shelley.DuplicateGenesisVrf.Error(failure)
+              } else if (errors.shelley.NonGenesisVoters.assert(failure)) {
+                return new errors.shelley.NonGenesisVoters.Error(failure)
+              } else if (errors.shelley.UpdateWrongEpoch.assert(failure)) {
+                return new errors.shelley.UpdateWrongEpoch.Error(failure)
+              } else if (errors.shelley.ProtocolVersionCannotFollow.assert(failure)) {
+                return new errors.shelley.ProtocolVersionCannotFollow.Error(failure)
+              } else if (errors.shelley.OutsideOfValidityInterval.assert(failure)) {
+                return new errors.shelley.OutsideOfValidityInterval.Error(failure)
+              } else if (errors.shelley.TriesToForgeAda.assert(failure)) {
+                return new errors.shelley.TriesToForgeAda.Error(failure)
+              } else if (errors.shelley.TooManyAssetsInOutput.assert(failure)) {
+                return new errors.shelley.TooManyAssetsInOutput.Error(failure)
+              } else {
+                return new Error(failure)
+              }
+            }))
           }
-        } else {
-          return reject(new UnknownResultError(response))
         }
-      })
-      socket.send(JSON.stringify({
-        ...baseRequest,
-        methodname: 'SubmitTx',
-        args: { bytes },
-        mirror: { requestId }
-      } as Ogmios['SubmitTx']))
-    })
-  },
-  context
-  )
-}
+      } else {
+        return reject(new UnknownResultError(response))
+      }
+    }
+  }, context)

--- a/clients/TypeScript/packages/client/test/StateQuery.test.ts
+++ b/clients/TypeScript/packages/client/test/StateQuery.test.ts
@@ -129,6 +129,19 @@ describe('Local state queries', () => {
 
         await client.release()
       })
+
+      it('can handle concurrent requests ', async () => {
+        const client = await createStateQueryClient({ connection })
+        const [currentEpoch, eraStart, ledgerTip] = await Promise.all([
+          client.currentEpoch(),
+          client.eraStart(),
+          client.ledgerTip()
+        ])
+        expect(currentEpoch).toBeDefined()
+        expect(eraStart).toBeDefined()
+        expect(ledgerTip).toBeDefined()
+        await client.release()
+      })
     })
   })
 


### PR DESCRIPTION
- adds a `Query` function to DRY up the code
- replaces self-removing event listeners, for the request-response
interactions, with manual removal of the listener after the handler
resolves.
- adds a test case to demonstrate concurrency when making state queries,
via the client.

Closes #40