### PR TITLE
fix: client TypeScript chain-sync sequential processing

### DIFF
--- a/clients/TypeScript/packages/client/package.json
+++ b/clients/TypeScript/packages/client/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "@cardano-ogmios/schema": "3.2.0",
+    "fastq": "^1.11.0",
     "isomorphic-ws": "^4.0.1",
     "nanoid": "^3.1.22",
     "ts-custom-error": "^3.2.0",

--- a/clients/TypeScript/packages/client/src/ChainSync/ChainSyncClient.ts
+++ b/clients/TypeScript/packages/client/src/ChainSync/ChainSyncClient.ts
@@ -15,7 +15,7 @@ export interface ChainSyncClient {
   shutdown: () => Promise<void>
   startSync: (
     points?: Point[],
-    requestBuffer?: number
+    inFlight?: number
   ) => Promise<Intersection>
 }
 
@@ -78,7 +78,7 @@ export const createChainSyncClient = async (
             socket.once('close', resolve)
             socket.close()
           }),
-          startSync: async (points, requestBuffer) => {
+          startSync: async (points, inFlight) => {
             const intersection = await findIntersect(
               points || [await createPointFromCurrentTip({ socket, closeOnCompletion: false })],
               {
@@ -87,7 +87,7 @@ export const createChainSyncClient = async (
               }
             )
             ensureSocketIsOpen(socket)
-            for (let n = 0; n < (requestBuffer || 100); n += 1) {
+            for (let n = 0; n < (inFlight || 100); n += 1) {
               requestNext(socket)
             }
             return intersection

--- a/clients/TypeScript/packages/client/test/ChainSync.test.ts
+++ b/clients/TypeScript/packages/client/test/ChainSync.test.ts
@@ -97,7 +97,7 @@ describe('ChainSync', () => {
 
     it('implements pipelining to increase sync performance', async () => {
       type BlocksPerSecond = number
-      const run = async (requestBuffer?: number): Promise<BlocksPerSecond> => {
+      const run = async (inFlight?: number): Promise<BlocksPerSecond> => {
         const blocks: Block[] = []
         const start = Date.now()
         let stop: number
@@ -116,7 +116,7 @@ describe('ChainSync', () => {
         }, {
           connection
         })
-        await client.startSync(['origin'], requestBuffer)
+        await client.startSync(['origin'], inFlight)
         await delay(2000)
         await client.shutdown()
         expect(blocks.length).toBe(1000)

--- a/clients/TypeScript/packages/repl/src/index.ts
+++ b/clients/TypeScript/packages/repl/src/index.ts
@@ -2,6 +2,7 @@ import repl from 'repl'
 import parser from 'yargs-parser'
 import {
   ChainSyncMessageHandlers,
+  ConnectionConfig,
   createChainSyncClient,
   createStateQueryClient,
   currentEpoch,
@@ -30,29 +31,23 @@ const logObject = (obj: Object) =>
   const connection = {
     host: args.host,
     port: args.port
-  }
+  } as ConnectionConfig
   const chainSync = await createChainSyncClient({
-    rollBackward: ({ point, tip, reflection }) => {
+    rollBackward: ({ point, tip }, requestNext) => {
       log(chalk.bgRedBright.bold('ROLL BACKWARD'))
       log(chalk.redBright.bold('Point'))
       logObject(point)
       log(chalk.redBright.bold('Tip'))
       logObject(tip)
-      if (reflection !== null) {
-        log(chalk.redBright.bold('Reflection'))
-        logObject(reflection)
-      }
+      requestNext()
     },
-    rollForward: ({ block, tip, reflection }) => {
+    rollForward: ({ block, tip }, requestNext) => {
       log(chalk.bgGreen.bold('ROLL FORWARD'))
       log(chalk.green.bold('Block'))
       logObject(block)
       log(chalk.green.bold('Tip'))
       logObject(tip)
-      if (reflection !== null) {
-        log(chalk.green.bold('Reflection'))
-        logObject(reflection)
-      }
+      requestNext()
     }
   }, {
     connection

--- a/clients/TypeScript/packages/repl/src/index.ts
+++ b/clients/TypeScript/packages/repl/src/index.ts
@@ -33,7 +33,7 @@ const logObject = (obj: Object) =>
     port: args.port
   } as ConnectionConfig
   const chainSync = await createChainSyncClient({
-    rollBackward: ({ point, tip }, requestNext) => {
+    rollBackward: async ({ point, tip }, requestNext) => {
       log(chalk.bgRedBright.bold('ROLL BACKWARD'))
       log(chalk.redBright.bold('Point'))
       logObject(point)
@@ -41,7 +41,7 @@ const logObject = (obj: Object) =>
       logObject(tip)
       requestNext()
     },
-    rollForward: ({ block, tip }, requestNext) => {
+    rollForward: async ({ block, tip }, requestNext) => {
       log(chalk.bgGreen.bold('ROLL FORWARD'))
       log(chalk.green.bold('Block'))
       logObject(block)

--- a/clients/TypeScript/yarn.lock
+++ b/clients/TypeScript/yarn.lock
@@ -2291,7 +2291,7 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fastq@^1.6.0:
+fastq@^1.11.0, fastq@^1.6.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.11.0.tgz#bb9fb955a07130a918eb63c1f5161cc32a5d0858"
   integrity sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==


### PR DESCRIPTION
**feature: client TypeScript chain-sync client requestNext improvement**

**BREAKING CHANGE:** ChainSyncClient no longer exposes a `requestNext`
function. Instead you must invoke the callback provided as the second
argument in each of rollBackward and rollForward handlers.

**BREAKING CHANGE:** ChainSyncClient no longer exposes JSON-WSP reflection,
as there would be unexpected results given the first n messages would all
share the same reflected value.
_____

**fix: queue client TypeScript chain-sync requestNext responses**
Implements an in-memory queue to ensure `requestNext` responses are processed
sequentially when there are async operations in the message handlers.

**BREAKING CHANGE:** The `ChainSyncClientMessageHandlers` methods now must return
a promise.

Note: The dependency introduced here is https://www.npmjs.com/package/fastq. 
