### PR TITLE
Alonzo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ pre: "<b>5. </b>"
 
 - :warning: **Breaking-Change** :warning: Transactions witnesses' `script` has been renamed into `scripts`.
 
+- :warning: **Breaking-Change** :warning: Transaction submission errors' `networkMismatch` now returns an `invalidEntities` list of object in the form of `{ "type": ..., "entity": }` where `type` is a text tag designating the type of entity for which there is a network identifier mismatch. Values can be `address`, `rewardAccount` and since Alonzo `transactionBody`. The `entity` field contains some details specific to the type of entity. Before, it used to be two distinct fields `invalidAddresses` and `invalidRewardAccounts`. 
+
 - The `moveInstantaneousRewards` certificates have a new optional field `value` and not only a `rewards` map as before. 
   When `value` is present, it signifies that rewards are moved to the other pot. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ pre: "<b>5. </b>"
 
 #### Changed
 
+- :warning: **Breaking-Change** :warning: Auxiliary data's `scriptPreImages` in Allegra & Mary has been replaced with a field `scripts` which has one field `native`. The value of `native` corresponds to what used to be the value of `scriptPreImages`. In Alonzo, `scripts` may also have another field `plutus` with a serialized Plutus script. 
+
+- :warning: **Breaking-Change** :warning: Transactions witnesses' `address` has been renamed into `signatures`, and the structure of the object has been changed to be a map from public keys to signatures (instead of an object with two field `key` & `signature`). 
+
+- :warning: **Breaking-Change** :warning: Transactions witnesses' `script` has been renamed into `scripts`.
+
 - The `moveInstantaneousRewards` certificates have a new optional field `value` and not only a `rewards` map as before. 
   When `value` is present, it signifies that rewards are moved to the other pot. 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 ARG CARDANO_NODE_VERSION=1.27.0
-ARG CARDANO_OGMIOS_SNAPSHOT=f5eb524a06bf2439707161f6256af1164e360eb0
+ARG CARDANO_OGMIOS_SNAPSHOT=46004deac7fb66a778ee9d684b70a105dbcf63ec
 ARG IOHK_LIBSODIUM_GIT_REV=66f017f16633f2060db25e17c170c2afa0f2a8a1
 
 #                                                                              #

--- a/docs/static/ogmios.wsp.json
+++ b/docs/static/ogmios.wsp.json
@@ -1108,7 +1108,7 @@
               , "proof": { "$ref": "#/definitions/BlockProof" }
               , "protocolMagicId": { "$ref": "#/definitions/ProtocolMagicId" }
               , "protocolVersion": { "$ref": "#/definitions/ProtocolVersion" }
-              , "signature": { "$ref": "#/definitions/Signature" }
+              , "signature": { "$ref": "#/definitions/BlockSignature" }
               , "slot": { "$ref": "#/definitions/Slot" }
               , "softwareVersion": { "$ref": "#/definitions/SoftwareVersion" }
               }
@@ -1236,15 +1236,12 @@
               , "update": null
               }
             , "witness":
-              { "address":
-                [ { "key": "386020d73807f285ba3259efacd9fbea1939ebd97dc2ddc3b178d427e5a047f6"
-                  , "signature": "5bckfySir7f4G+SV83UPw0+42qqFcEU+sdmK+uejnx6gn6OFMckasHBY8xPWabJ9w5xMmD8sRJ5VC7bNsUU0Ag=="
-                  }
-                , { "key": "de735ba8771f521b50bc3130c4a7d6f0784df718d3ed3ca32befd9a4650c2e8a"
-                  , "signature": "KHlV88SX+sODj4EqHW7U1wxLL2nVuq/wg43rdaarckroEZc3k1h7YcH0CyAoBvy5+xv6aZ6clDvceeUliD6RCw=="
+              { "signatures":
+                [ { "386020d73807f285ba3259efacd9fbea1939ebd97dc2ddc3b178d427e5a047f6": "5bckfySir7f4G+SV83UPw0+42qqFcEU+sdmK+uejnx6gn6OFMckasHBY8xPWabJ9w5xMmD8sRJ5VC7bNsUU0Ag=="
+                  , "de735ba8771f521b50bc3130c4a7d6f0784df718d3ed3ca32befd9a4650c2e8a": "KHlV88SX+sODj4EqHW7U1wxLL2nVuq/wg43rdaarckroEZc3k1h7YcH0CyAoBvy5+xv6aZ6clDvceeUliD6RCw=="
                   }
                 ]
-              , "script": {}
+              , "scripts": {}
               , "bootstrap": []
               }
             , "metadata":
@@ -1320,22 +1317,15 @@
             , "witness":
               { "type": "object"
               , "additionalProperties": false
-              , "required": ["address","script","bootstrap"]
+              , "required": ["signatures","scripts","bootstrap"]
               , "properties":
-                { "address":
+                { "signatures":
                   { "type": "array"
-                  , "items":
-                    { "type": "object"
-                    , "additionalProperties": false
-                    , "properties":
-                      { "signature": { "$ref": "#/definitions/Hash64" }
-                      , "key": { "$ref": "#/definitions/Hash16" }
-                      }
-                    }
+                  , "items": { "$ref": "#/definitions/Signature" }
                   }
-                , "script":
+                , "scripts":
                   { "type": "object"
-                  , "propertyNames": { "contentEncoding": "bech32", "pattern": "^[0-9a-f]+$" }
+                  , "propertyNames": { "contentEncoding": "base16", "pattern": "^[0-9a-f]+$" }
                   , "additionalProperties": { "$ref": "#/definitions/Script" }
                   }
                 , "bootstrap":
@@ -1370,14 +1360,14 @@
               , "properties":
                 { "hash":
                   { "oneOf":
-                    [ { "type": "null", "title": "null" }
-                    , { "$ref": "#/definitions/Hash16" }
+                    [ { "$ref": "#/definitions/Hash16" }
+                    , { "type": "null", "title": "null" }
                     ]
                   }
                 , "body":
                   { "oneOf":
-                    [ { "type": "null", "title": "null" }
-                    , { "type": "object", "title": "object" }
+                    [ { "$ref": "#/definitions/AuxiliaryData" }
+                    , { "type": "null", "title": "null" }
                     ]
                   }
                 }
@@ -1444,15 +1434,12 @@
               , "update": null
               }
             , "witness":
-              { "address":
-                [ { "key": "386020d73807f285ba3259efacd9fbea1939ebd97dc2ddc3b178d427e5a047f6"
-                  , "signature": "5bckfySir7f4G+SV83UPw0+42qqFcEU+sdmK+uejnx6gn6OFMckasHBY8xPWabJ9w5xMmD8sRJ5VC7bNsUU0Ag=="
-                  }
-                , { "key": "de735ba8771f521b50bc3130c4a7d6f0784df718d3ed3ca32befd9a4650c2e8a"
-                  , "signature": "KHlV88SX+sODj4EqHW7U1wxLL2nVuq/wg43rdaarckroEZc3k1h7YcH0CyAoBvy5+xv6aZ6clDvceeUliD6RCw=="
+              { "signatures":
+                [ { "386020d73807f285ba3259efacd9fbea1939ebd97dc2ddc3b178d427e5a047f6": "5bckfySir7f4G+SV83UPw0+42qqFcEU+sdmK+uejnx6gn6OFMckasHBY8xPWabJ9w5xMmD8sRJ5VC7bNsUU0Ag=="
+                  , "de735ba8771f521b50bc3130c4a7d6f0784df718d3ed3ca32befd9a4650c2e8a": "KHlV88SX+sODj4EqHW7U1wxLL2nVuq/wg43rdaarckroEZc3k1h7YcH0CyAoBvy5+xv6aZ6clDvceeUliD6RCw=="
                   }
                 ]
-              , "script": {}
+              , "scripts": {}
               , "bootstrap": []
               }
             , "metadata":
@@ -1528,22 +1515,15 @@
             , "witness":
               { "type": "object"
               , "additionalProperties": false
-              , "required": ["address","script","bootstrap"]
+              , "required": ["signatures","scripts","bootstrap"]
               , "properties":
-                { "address":
+                { "signatures":
                   { "type": "array"
-                  , "items":
-                    { "type": "object"
-                    , "additionalProperties": false
-                    , "properties":
-                      { "signature": { "$ref": "#/definitions/Hash64" }
-                      , "key": { "$ref": "#/definitions/Hash16" }
-                      }
-                    }
+                  , "items": { "$ref": "#/definitions/Signature" }
                   }
-                , "script":
+                , "scripts":
                   { "type": "object"
-                  , "propertyNames": { "contentEncoding": "bech32", "pattern": "^[0-9a-f]+$" }
+                  , "propertyNames": { "contentEncoding": "base16", "pattern": "^[0-9a-f]+$" }
                   , "additionalProperties": { "$ref": "#/definitions/Script" }
                   }
                 , "bootstrap":
@@ -1578,14 +1558,14 @@
               , "properties":
                 { "hash":
                   { "oneOf":
-                    [ { "type": "null", "title": "null" }
-                    , { "$ref": "#/definitions/Hash16" }
+                    [ { "$ref": "#/definitions/Hash16" }
+                    , { "type": "null", "title": "null" }
                     ]
                   }
                 , "body":
                   { "oneOf":
-                    [ { "type": "null", "title": "null" }
-                    , { "type": "object", "title": "object" }
+                    [ { "$ref": "#/definitions/AuxiliaryData" }
+                    , { "type": "null", "title": "null" }
                     ]
                   }
                 }
@@ -1640,15 +1620,12 @@
                 }
               }
             , "witness":
-              { "address":
-                [ { "key": "a900560b6c0964492849eb5311acac881edeb8d2282122b895fd418243c92f4e"
-                  , "signature": "3TLin5vgz4dQDomhMjW9q4VIQD/X6Q9ECWkA8kVOz/c8R2c4mO1P1+LD/9n2ouHOANNC5ZgzwV2ojAVpZw4IBA=="
+              { "signatures":
+                [ { "a900560b6c0964492849eb5311acac881edeb8d2282122b895fd418243c92f4e": "3TLin5vgz4dQDomhMjW9q4VIQD/X6Q9ECWkA8kVOz/c8R2c4mO1P1+LD/9n2ouHOANNC5ZgzwV2ojAVpZw4IBA=="
+                  , "5c19b9b0dd58b782dcac33cdc925f74c1385d8aae5912f7e1040a2d24a47e4eb": "qjqis5n/XGVp5PCIe0h8h/+ZO6rdIClBfzb7SEaaG4kAuY+zMAnfA57oxcLI6MA81rJ/nVct7FDtLKEHjimlDg=="
                   }
-                , { "key": "5c19b9b0dd58b782dcac33cdc925f74c1385d8aae5912f7e1040a2d24a47e4eb"
-                  , "signature": "qjqis5n/XGVp5PCIe0h8h/+ZO6rdIClBfzb7SEaaG4kAuY+zMAnfA57oxcLI6MA81rJ/nVct7FDtLKEHjimlDg=="
-                  }
-                 ]
-              , "script": {}
+                ]
+              , "scripts": {}
               , "bootstrap": []
               }
             , "metadata":
@@ -1662,7 +1639,7 @@
                       ]
                     }
                   }
-                , "scriptPreImages": []
+                , "scripts": []
                 }
               }
             }
@@ -1735,22 +1712,15 @@
             , "witness":
               { "type": "object"
               , "additionalProperties": false
-              , "required": ["address","script","bootstrap"]
+              , "required": ["signatures","scripts","bootstrap"]
               , "properties":
-                { "address":
+                { "signatures":
                   { "type": "array"
-                  , "items":
-                    { "type": "object"
-                    , "additionalProperties": false
-                    , "properties":
-                      { "signature": { "$ref": "#/definitions/Hash64" }
-                      , "key": { "$ref": "#/definitions/Hash16" }
-                      }
-                    }
+                  , "items": { "$ref": "#/definitions/Signature" }
                   }
-                , "script":
+                , "scripts":
                   { "type": "object"
-                  , "propertyNames": { "contentEncoding": "bech32", "pattern": "^[0-9a-f]+$" }
+                  , "propertyNames": { "contentEncoding": "base16", "pattern": "^[0-9a-f]+$" }
                   , "additionalProperties": { "$ref": "#/definitions/Script" }
                   }
                 , "bootstrap":
@@ -1785,14 +1755,14 @@
               , "properties":
                 { "hash":
                   { "oneOf":
-                    [ { "type": "null", "title": "null" }
-                    , { "$ref": "#/definitions/Hash16" }
+                    [ { "$ref": "#/definitions/Hash16" }
+                    , { "type": "null", "title": "null" }
                     ]
                   }
                 , "body":
                   { "oneOf":
-                    [ { "type": "null", "title": "null" }
-                    , { "type": "object", "title": "null" }
+                    [ { "$ref": "#/definitions/AuxiliaryData" }
+                    , { "type": "null", "title": "null" }
                     ]
                   }
                 }
@@ -1831,6 +1801,16 @@
         }
       , "delegation": { "$ref": "#/definitions/Hash16" }
       , "update": { "$ref": "#/definitions/Hash16" }
+      }
+    }
+
+  , "BlockSignature":
+    { "type": "object"
+    , "additionalProperties": false
+    , "required": [ "dlgCertificate", "signature" ]
+    , "properties":
+      { "dlgCertificate": { "$ref": "#/definitions/DlgCertificate" }
+      , "signature": { "$ref": "#/definitions/Hash64" }
       }
     }
 
@@ -2176,6 +2156,44 @@
     , "pattern": "^[A-Za-z0-9+/]*=?=?$"
     }
 
+  , "InvalidEntity":
+    { "oneOf":
+      [ { "type": "object"
+        , "additionalProperties": false
+        , "required": [ "type", "entity" ]
+        , "properties":
+          { "type":
+            { "type": "string"
+            , "enum": [ "address" ]
+            }
+          , "entity": { "$ref": "#/definitions/Address" }
+          }
+        }
+      , { "type": "object"
+        , "additionalProperties": false
+        , "required": [ "type", "entity" ]
+        , "properties":
+          { "type":
+            { "type": "string"
+            , "enum": [ "poolRegistration" ]
+            }
+          , "entity": { "$ref": "#/definitions/PoolId" }
+          }
+        }
+      , { "type": "object"
+        , "additionalProperties": false
+        , "required": [ "type", "entity" ]
+        , "properties":
+          { "type":
+            { "type": "string"
+            , "enum": [ "rewardAccount" ]
+            }
+          , "entity": { "$ref": "#/definitions/RewardAccount" }
+          }
+        }
+      ]
+    }
+
   , "LeaderValue":
     { "type": "object"
     , "description": "In Ouroboros Praos, designate the leader's contribution to the Multi-Party computation used for calculating the leader schedule."
@@ -2232,6 +2250,91 @@
         , "required": [ "overflow" ]
         , "properties":
           { "overflow": { "type": "integer" }
+          }
+        }
+      ]
+    }
+
+  , "AuxiliaryData":
+    { "type": "object"
+    , "additionalProperties": false
+    , "properties":
+      { "blob": { "$ref": "#/definitions/Metadata" }
+      , "scripts":
+        { "type": "array"
+        , "items": { "$ref": "#/definitions/Script" }
+        }
+      }
+    }
+
+  , "Metadata":
+    { "type": "object"
+    , "propertyNames": { "pattern": "^-?[0-9]+$" }
+    , "additionalProperties": { "$ref": "#/definitions/Metadatum" }
+    }
+
+  , "Metadatum":
+    { "oneOf":
+      [ { "type": "object"
+        , "title": "int"
+        , "additionalProperties": false
+        , "required": ["int"]
+        , "properties":
+          { "int":
+              { "type": "integer"
+              }
+          }
+        }
+      , { "type": "object"
+        , "title": "string"
+        , "additionalProperties": false
+        , "required": ["string"]
+        , "properties":
+          { "string":
+              { "type": "string"
+              }
+          }
+        }
+      , { "type": "object"
+        , "title": "bytes"
+        , "additionalProperties": false
+        , "required": ["bytes"]
+        , "properties":
+          { "bytes":
+            { "type": "string"
+            , "contentEncoding": "base16"
+            , "pattern": "^[0-9a-f]*$"
+            }
+          }
+        }
+      , { "type": "object"
+        , "title": "list"
+        , "additionalProperties": false
+        , "required": ["list"]
+        , "properties":
+          { "list":
+            { "type": "array"
+            , "items": { "$ref": "#/definitions/Metadatum" }
+            }
+          }
+        }
+      , { "type": "object"
+        , "title": "map"
+        , "additionalProperties": false
+        , "required": ["map"]
+        , "properties":
+          { "map":
+            { "type": "array"
+            , "items":
+              { "type": "object"
+              , "additionalProperties": false
+              , "required": ["k", "v"]
+              , "properties":
+                { "k": { "$ref": "#/definitions/Metadatum" }
+                , "v": { "$ref": "#/definitions/Metadatum" }
+                }
+              }
+            }
           }
         }
       ]
@@ -2565,6 +2668,27 @@
     }
 
   , "Script":
+    { "oneOf":
+      [ { "type": "object"
+        , "title": "Native"
+        , "additionalProperties": false
+        , "required": [ "native" ]
+        , "properties":
+          { "native": { "$ref": "#/definitions/Script[Native]" }
+          }
+        }
+      , { "type": "object"
+        , "title": "Plutus"
+        , "additionalProperties": false
+        , "required": [ "plutus" ]
+        , "properties":
+          { "plutus": { "$ref": "#/definitions/Script[Plutus]" }
+          }
+        }
+      ]
+    }
+
+  , "Script[Native]":
     { "description": "A phase-1 monetary script. Timelocks constraints are only supported since Allegra."
     , "examples":
         [ "3c07030e36bfff7cd2f004356ef320f3fe3c07030e7cd2f004356437"
@@ -2599,34 +2723,37 @@
       , { "type": "object"
         , "title": "any"
         , "additionalProperties": false
+        , "required": ["any"]
         , "properties":
           { "any":
             { "type": "array"
-            , "items": { "$ref": "#/definitions/Script" }
+            , "items": { "$ref": "#/definitions/Script[Native]" }
             }
           }
         }
       , { "type": "object"
-        , "additionalProperties": false
         , "title": "all"
+        , "additionalProperties": false
+        , "required": ["all"]
         , "properties":
           { "all":
             { "type": "array"
-            , "items": { "$ref": "#/definitions/Script" }
+            , "items": { "$ref": "#/definitions/Script[Native]" }
             }
           }
         }
       , { "type": "object"
-        , "propertyNames": { "pattern": "[0-9]+$" }
         , "title": "NOf"
+        , "propertyNames": { "pattern": "^[0-9]+$" }
         , "additionalProperties":
           { "type": "array"
-          , "items": { "$ref": "#/definitions/Script" }
+          , "items": { "$ref": "#/definitions/Script[Native]" }
           }
         }
       , { "type": "object"
         , "title": "expiresAt"
         , "additionalProperties": false
+        , "required": [ "expiresAt" ]
         , "properties":
           { "expiresAt": { "$ref": "#/definitions/Slot" }
           }
@@ -2634,6 +2761,7 @@
       , { "type": "object"
         , "title": "startsAt"
         , "additionalProperties": false
+        , "required": [ "startsAt" ]
         , "properties":
           { "startsAt": { "$ref": "#/definitions/Slot" }
           }
@@ -2641,14 +2769,17 @@
       ]
     }
 
+  , "Script[Plutus]":
+    { "type": "string"
+    , "description": "A phase-2 Plutus script; or said differently, a serialized Plutus-core program."
+    , "contentEncoding": "base64"
+    , "pattern": "^[A-Za-z0-9+/]*=?=?$"
+    }
+
   , "Signature":
     { "type": "object"
-    , "additionalProperties": false
-    , "required": [ "dlgCertificate", "signature" ]
-    , "properties":
-      { "dlgCertificate": { "$ref": "#/definitions/DlgCertificate" }
-      , "signature": { "$ref": "#/definitions/Hash64" }
-      }
+    , "additionalProperties": { "$ref": "#/definitions/Hash64" }
+    , "propertyNames": { "contentEncoding": "base16", "pattern": "^[0-9a-f]+$" }
     }
 
   , "Slot":
@@ -2986,33 +3117,16 @@
     , "required": [ "networkMismatch" ]
     , "properties":
       { "networkMismatch":
-        { "oneOf":
-          [ { "type": "object"
-            , "title": "In address"
-            , "additionalProperties": false
-            , "required": [ "expectedNetwork" ]
-            , "properties":
-              { "expectedNetwork": { "$ref": "#/definitions/Network" }
-              , "invalidAddresses":
-                { "type": "array"
-                , "items": { "$ref": "#/definitions/Address" }
-                }
-              , "invalidRewardAccounts":
-                { "type": "array"
-                , "items": { "$ref": "#/definitions/RewardAccount" }
-                }
-              }
+        { "type": "object"
+        , "additionalProperties": false
+        , "required": [ "expectedNetwork", "invalidEntities" ]
+        , "properties":
+          { "expectedNetwork": { "$ref": "#/definitions/Network" }
+          , "invalidEntities":
+            { "type": "array"
+            , "items": { "$ref": "#/definitions/InvalidEntity" }
             }
-          , { "type": "object"
-            , "title": "In pool certificate"
-            , "additionalProperties": false
-            , "required": [ "expectedNetwork", "invalidPoolRegistration" ]
-            , "properties":
-              { "expectedNetwork": { "$ref": "#/definitions/Network" }
-              , "invalidPoolRegistration": { "$ref": "#/definitions/PoolId" }
-              }
-            }
-          ]
+          }
         }
       }
     }

--- a/server/cabal.project
+++ b/server/cabal.project
@@ -24,6 +24,10 @@ package ogmios
 package cryptonite
   flags: -support_rdrand
 
+allow-newer:
+  monoidal-containers:aeson,
+  size-based:template-haskell
+
 -- The "cabal" wrapper script provided by nix-shell will cut off / restore the remainder of this file
 -- in order to force usage of nix provided dependencies for `source-repository-package`.
 -- --------------------------- 8< --------------------------
@@ -32,8 +36,8 @@ package cryptonite
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 47db5b818ca4fa051f2e44cdf5e7c5c18c1fb0bf
-  --sha256: 0fr0r5dwfmsp15j19xh20js8nzsqyhwx4q797rxsvpyjfabb2y11
+  tag: a715c7f420770b70bbe95ca51d3dec83866cb1bd
+  --sha256: 06l06mmb8cd4q37bnvfpgx1c5zgsl4xaf106dqva98738i8asj7j
   subdir:
     binary
     binary/test
@@ -46,15 +50,17 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-crypto
-  tag: f73079303f663e028288f9f4a9e08bcca39a923e
-  --sha256: 1n87i15x54s0cjkh3nsxs4r1x016cdw1fypwmr68936n3xxsjn6q
+  tag: ce8f1934e4b6252084710975bd9bbc0a4648ece4
+  --sha256: 1v2laq04piyj511b2m77hxjh9l1yd6k9kc7g6bjala4w3zdwa4ni
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: e8f19bcc9c8f405131cb95ca6ada26b2b4eac638
-  --sha256: 1v36d3lyhmadzj0abdfsppjna7n7llzqzp9ikx5yq28l2kda2f1p
+  tag: 41b02e51d3e0a4826264fc4ae595a9dd6a7d8849
+  --sha256: 0gn3qiq4n8xgb038qravwiikjf26i5fshkh7w16s3gax6z7c9i3b
   subdir:
+    alonzo/impl
+    alonzo/test
     byron/chain/executable-spec
     byron/crypto
     byron/crypto/test
@@ -73,8 +79,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: 8fe46140a52810b6ca456be01d652ca08fe730bf
-  --sha256: 1c9zc899wlgicrs49i33l0bwb554acsavzh1vcyhnxmpm0dmy8vj
+  tag: b83e4025785be16cb5ee5231a6e9939d93564b40
+  --sha256: 1zvgrb7h1v65mf3wqk4nx8a2qjmbwx1hbz2amszbmrwzi30cz5vq
   subdir:
     cardano-api
     cardano-config
@@ -82,8 +88,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: bb4ed71ba8e587f672d06edf9d2e376f4b055555
-  --sha256: 00h10l5mmiza9819p9v5q5749nb9pzgi20vpzpy1d34zmh6gf1cj
+  tag: fd773f7a58412131512b9f694ab95653ac430852
+  --sha256: 02jddik1yw0222wd6q0vv10f7y8rdgrlqaiy83ph002f9kjx7mh6
   subdir:
     cardano-prelude
     cardano-prelude-test
@@ -130,8 +136,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 9b279c7548ee549e1ed755cd1acb69b6e69d0c7b
-  --sha256: 0d7bk9vzmhhb2z4ns2qw7f1vz6lr186m98sh8wvrnfpxk3z86dxb
+  tag: 8bbded8a3a6e967ce67fbcaf50579d3719e52bef
+  --sha256: 1j9vdfvqkdl6qs6xp9n19y9hvfnxqii6awqwrf1ahlfbk9r3fwmb
   subdir:
     io-sim
     io-sim-classes
@@ -151,6 +157,17 @@ source-repository-package
     ouroboros-network-testing
     typed-protocols
     typed-protocols-examples
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/plutus
+  tag: 530d3f7940319788a49c7ecb017f8366994990b0
+  --sha256: 01jzrl04zyp63c9sxd1qgdy4nxbnaz7n2g1pw4x2d5y9562mrq6v
+  subdir:
+    plutus-core
+    plutus-ledger-api
+    plutus-tx
+    prettyprinter-configurable
 
 source-repository-package
   type: git

--- a/server/modules/cardano-client/cardano-client.cabal
+++ b/server/modules/cardano-client/cardano-client.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.2.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c9dd69dfa9313737bf57ada1ea91d1cdde6c2de48bf658f5b3d546d02e05ecbe
+-- hash: af817fcd073b7f00a7e40f90315ee4563e0b03a3a743f7d9ca53ce6cdf3d0d28
 
 name:           cardano-client
 version:        1.0.0
@@ -36,8 +36,42 @@ library
       Paths_cardano_client
   hs-source-dirs:
       src
-  default-extensions: BangPatterns BinaryLiterals ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable EmptyDataDecls ExistentialQuantification FlexibleContexts FlexibleInstances FunctionalDependencies GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude NumericUnderscores OverloadedStrings PartialTypeSignatures PatternGuards RankNTypes ScopedTypeVariables StandaloneDeriving TupleSections TypeFamilies TypeSynonymInstances ViewPatterns
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+  default-extensions:
+      BangPatterns
+      BinaryLiterals
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveDataTypeable
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveTraversable
+      EmptyDataDecls
+      ExistentialQuantification
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      InstanceSigs
+      KindSignatures
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      NoImplicitPrelude
+      NumericUnderscores
+      OverloadedStrings
+      PartialTypeSignatures
+      PatternGuards
+      RankNTypes
+      ScopedTypeVariables
+      StandaloneDeriving
+      TupleSections
+      TypeFamilies
+      TypeSynonymInstances
+      ViewPatterns
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints -Wunused-packages
   build-tool-depends:
       hspec-discover:hspec-discover
   build-depends:

--- a/server/modules/cardano-client/src/Cardano/Network/Protocol/NodeToClient.hs
+++ b/server/modules/cardano-client/src/Cardano/Network/Protocol/NodeToClient.hs
@@ -68,13 +68,15 @@ import Network.Mux
 import Network.TypedProtocol.Codec
     ( Codec )
 import Ouroboros.Consensus.Byron.Ledger
-    ( GenTx, Query (..) )
+    ( GenTx )
 import Ouroboros.Consensus.Byron.Ledger.Config
     ( CodecConfig (..) )
 import Ouroboros.Consensus.Cardano
     ( CardanoBlock )
 import Ouroboros.Consensus.Cardano.Block
     ( CardanoEras, CodecConfig (..), HardForkApplyTxErr )
+import Ouroboros.Consensus.Ledger.Query
+    ( Query (..) )
 import Ouroboros.Consensus.Network.NodeToClient
     ( ClientCodecs, Codecs' (..), clientCodecs )
 import Ouroboros.Consensus.Node.NetworkProtocolVersion
@@ -301,12 +303,13 @@ codecs epochSlots =
     clientCodecs cfg (supportedVersions ! nodeToClientV) nodeToClientV
   where
     supportedVersions = supportedNodeToClientVersions (Proxy @Block)
-    cfg = CardanoCodecConfig byron shelley allegra mary
+    cfg = CardanoCodecConfig byron shelley allegra mary alonzo
       where
         byron   = ByronCodecConfig epochSlots
         shelley = ShelleyCodecConfig
         allegra = ShelleyCodecConfig
         mary    = ShelleyCodecConfig
+        alonzo  = ShelleyCodecConfig
 
 nodeToClientV :: NodeToClientVersion
-nodeToClientV = NodeToClientV_8
+nodeToClientV = NodeToClientV_9

--- a/server/modules/cardano-client/src/Cardano/Network/Protocol/NodeToClient.hs
+++ b/server/modules/cardano-client/src/Cardano/Network/Protocol/NodeToClient.hs
@@ -311,5 +311,6 @@ codecs epochSlots =
         mary    = ShelleyCodecConfig
         alonzo  = ShelleyCodecConfig
 
+-- TODO: Switch to NodeToClientV_9 as soon as Alonzo node are ready
 nodeToClientV :: NodeToClientVersion
-nodeToClientV = NodeToClientV_9
+nodeToClientV = NodeToClientV_8

--- a/server/modules/fast-bech32/fast-bech32.cabal
+++ b/server/modules/fast-bech32/fast-bech32.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 77086e2a0a4e59f8f6931d019f2b119f522fe3b996d80e57da5d7335e620282b
+-- hash: c90aa64d9b573bd74e26c606bccc9065e63e43f351c94f930b404bfa961fc685
 
 name:           fast-bech32
 version:        1.0.0
@@ -35,7 +35,41 @@ library
       Paths_fast_bech32
   hs-source-dirs:
       src
-  default-extensions: BangPatterns BinaryLiterals ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable EmptyDataDecls ExistentialQuantification FlexibleContexts FlexibleInstances FunctionalDependencies GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude NumericUnderscores OverloadedStrings PartialTypeSignatures PatternGuards RankNTypes ScopedTypeVariables StandaloneDeriving TupleSections TypeFamilies TypeSynonymInstances ViewPatterns
+  default-extensions:
+      BangPatterns
+      BinaryLiterals
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveDataTypeable
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveTraversable
+      EmptyDataDecls
+      ExistentialQuantification
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      InstanceSigs
+      KindSignatures
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      NoImplicitPrelude
+      NumericUnderscores
+      OverloadedStrings
+      PartialTypeSignatures
+      PatternGuards
+      RankNTypes
+      ScopedTypeVariables
+      StandaloneDeriving
+      TupleSections
+      TypeFamilies
+      TypeSynonymInstances
+      ViewPatterns
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints -Wunused-packages
   build-depends:
       base >=4.7 && <5
@@ -54,7 +88,41 @@ test-suite unit
       Paths_fast_bech32
   hs-source-dirs:
       test/unit
-  default-extensions: BangPatterns BinaryLiterals ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable EmptyDataDecls ExistentialQuantification FlexibleContexts FlexibleInstances FunctionalDependencies GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude NumericUnderscores OverloadedStrings PartialTypeSignatures PatternGuards RankNTypes ScopedTypeVariables StandaloneDeriving TupleSections TypeFamilies TypeSynonymInstances ViewPatterns
+  default-extensions:
+      BangPatterns
+      BinaryLiterals
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveDataTypeable
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveTraversable
+      EmptyDataDecls
+      ExistentialQuantification
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      InstanceSigs
+      KindSignatures
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      NoImplicitPrelude
+      NumericUnderscores
+      OverloadedStrings
+      PartialTypeSignatures
+      PatternGuards
+      RankNTypes
+      ScopedTypeVariables
+      StandaloneDeriving
+      TupleSections
+      TypeFamilies
+      TypeSynonymInstances
+      ViewPatterns
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
   build-tool-depends:
       hspec-discover:hspec-discover
@@ -76,7 +144,41 @@ benchmark encoding
       Paths_fast_bech32
   hs-source-dirs:
       bench
-  default-extensions: BangPatterns BinaryLiterals ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable EmptyDataDecls ExistentialQuantification FlexibleContexts FlexibleInstances FunctionalDependencies GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude NumericUnderscores OverloadedStrings PartialTypeSignatures PatternGuards RankNTypes ScopedTypeVariables StandaloneDeriving TupleSections TypeFamilies TypeSynonymInstances ViewPatterns
+  default-extensions:
+      BangPatterns
+      BinaryLiterals
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveDataTypeable
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveTraversable
+      EmptyDataDecls
+      ExistentialQuantification
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      InstanceSigs
+      KindSignatures
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      NoImplicitPrelude
+      NumericUnderscores
+      OverloadedStrings
+      PartialTypeSignatures
+      PatternGuards
+      RankNTypes
+      ScopedTypeVariables
+      StandaloneDeriving
+      TupleSections
+      TypeFamilies
+      TypeSynonymInstances
+      ViewPatterns
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5

--- a/server/modules/git-th/git-th.cabal
+++ b/server/modules/git-th/git-th.cabal
@@ -1,10 +1,10 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.34.2.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d7bc26e05c6f51c29027b230fd4987aaebdec2ff88d7d2a51c42e4cee89d10d8
+-- hash: 9fe72c702b3f7a826e779f1407b4cf146972bc25857bc67f198bee7cffcaf574
 
 name:           git-th
 version:        1.0.0
@@ -35,8 +35,42 @@ library
       Paths_git_th
   hs-source-dirs:
       src
-  default-extensions: BangPatterns BinaryLiterals ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable EmptyDataDecls ExistentialQuantification FlexibleContexts FlexibleInstances FunctionalDependencies GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude NumericUnderscores OverloadedStrings PartialTypeSignatures PatternGuards RankNTypes ScopedTypeVariables StandaloneDeriving TupleSections TypeFamilies TypeSynonymInstances ViewPatterns
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+  default-extensions:
+      BangPatterns
+      BinaryLiterals
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveDataTypeable
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveTraversable
+      EmptyDataDecls
+      ExistentialQuantification
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      InstanceSigs
+      KindSignatures
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      NoImplicitPrelude
+      NumericUnderscores
+      OverloadedStrings
+      PartialTypeSignatures
+      PatternGuards
+      RankNTypes
+      ScopedTypeVariables
+      StandaloneDeriving
+      TupleSections
+      TypeFamilies
+      TypeSynonymInstances
+      ViewPatterns
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints -Wunused-packages
   build-tools:
       git
   build-depends:
@@ -53,8 +87,42 @@ test-suite integration
       Paths_git_th
   hs-source-dirs:
       test/unit
-  default-extensions: BangPatterns BinaryLiterals ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable EmptyDataDecls ExistentialQuantification FlexibleContexts FlexibleInstances FunctionalDependencies GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude NumericUnderscores OverloadedStrings PartialTypeSignatures PatternGuards RankNTypes ScopedTypeVariables StandaloneDeriving TupleSections TypeFamilies TypeSynonymInstances ViewPatterns
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
+  default-extensions:
+      BangPatterns
+      BinaryLiterals
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveDataTypeable
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveTraversable
+      EmptyDataDecls
+      ExistentialQuantification
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      InstanceSigs
+      KindSignatures
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      NoImplicitPrelude
+      NumericUnderscores
+      OverloadedStrings
+      PartialTypeSignatures
+      PatternGuards
+      RankNTypes
+      ScopedTypeVariables
+      StandaloneDeriving
+      TupleSections
+      TypeFamilies
+      TypeSynonymInstances
+      ViewPatterns
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
   build-tool-depends:
       hspec-discover:hspec-discover
   build-depends:

--- a/server/modules/hspec-json-schema/hspec-json-schema.cabal
+++ b/server/modules/hspec-json-schema/hspec-json-schema.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.2.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 8c53fbdf7dd0b62fe5297457301d33dfc4cb0b78d2a1bbb29b125d21203b1f35
+-- hash: c493b35deaf5a81307a975c77f4efd841e300f49cdf54fd602d1df5a6e569bab
 
 name:           hspec-json-schema
 version:        1.0.0
@@ -35,7 +35,41 @@ library
       Paths_hspec_json_schema
   hs-source-dirs:
       src
-  default-extensions: BangPatterns BinaryLiterals ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable EmptyDataDecls ExistentialQuantification FlexibleContexts FlexibleInstances FunctionalDependencies GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude NumericUnderscores OverloadedStrings PartialTypeSignatures PatternGuards RankNTypes ScopedTypeVariables StandaloneDeriving TupleSections TypeFamilies TypeSynonymInstances ViewPatterns
+  default-extensions:
+      BangPatterns
+      BinaryLiterals
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveDataTypeable
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveTraversable
+      EmptyDataDecls
+      ExistentialQuantification
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      InstanceSigs
+      KindSignatures
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      NoImplicitPrelude
+      NumericUnderscores
+      OverloadedStrings
+      PartialTypeSignatures
+      PatternGuards
+      RankNTypes
+      ScopedTypeVariables
+      StandaloneDeriving
+      TupleSections
+      TypeFamilies
+      TypeSynonymInstances
+      ViewPatterns
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints -Wunused-packages
   build-depends:
       QuickCheck
@@ -59,7 +93,41 @@ test-suite unit
       Paths_hspec_json_schema
   hs-source-dirs:
       test
-  default-extensions: BangPatterns BinaryLiterals ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable EmptyDataDecls ExistentialQuantification FlexibleContexts FlexibleInstances FunctionalDependencies GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude NumericUnderscores OverloadedStrings PartialTypeSignatures PatternGuards RankNTypes ScopedTypeVariables StandaloneDeriving TupleSections TypeFamilies TypeSynonymInstances ViewPatterns
+  default-extensions:
+      BangPatterns
+      BinaryLiterals
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveDataTypeable
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveTraversable
+      EmptyDataDecls
+      ExistentialQuantification
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      InstanceSigs
+      KindSignatures
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      NoImplicitPrelude
+      NumericUnderscores
+      OverloadedStrings
+      PartialTypeSignatures
+      PatternGuards
+      RankNTypes
+      ScopedTypeVariables
+      StandaloneDeriving
+      TupleSections
+      TypeFamilies
+      TypeSynonymInstances
+      ViewPatterns
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
   build-tool-depends:
       hspec-discover:hspec-discover

--- a/server/modules/json-via-show/json-via-show.cabal
+++ b/server/modules/json-via-show/json-via-show.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6db91ee1f30e84fc22c74c064d770dbe7a09eb627f27076996d2cf61a1d057ee
+-- hash: 6e47685e6bbe363a3b404851f7f2467b33367856a83f9b15a0e89d0d0dacaa10
 
 name:           json-via-show
 version:        1.0.0
@@ -35,7 +35,41 @@ library
       Paths_json_via_show
   hs-source-dirs:
       src
-  default-extensions: BangPatterns BinaryLiterals ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable EmptyDataDecls ExistentialQuantification FlexibleContexts FlexibleInstances FunctionalDependencies GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude NumericUnderscores OverloadedStrings PartialTypeSignatures PatternGuards RankNTypes ScopedTypeVariables StandaloneDeriving TupleSections TypeFamilies TypeSynonymInstances ViewPatterns
+  default-extensions:
+      BangPatterns
+      BinaryLiterals
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveDataTypeable
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveTraversable
+      EmptyDataDecls
+      ExistentialQuantification
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      InstanceSigs
+      KindSignatures
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      NoImplicitPrelude
+      NumericUnderscores
+      OverloadedStrings
+      PartialTypeSignatures
+      PatternGuards
+      RankNTypes
+      ScopedTypeVariables
+      StandaloneDeriving
+      TupleSections
+      TypeFamilies
+      TypeSynonymInstances
+      ViewPatterns
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints -Wunused-packages
   build-depends:
       aeson

--- a/server/modules/json-wsp/json-wsp.cabal
+++ b/server/modules/json-wsp/json-wsp.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.2.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: b4a90f90c64a80a4ad9054bcc058f807aabe032702e9977e027bf8a134410a82
+-- hash: cb9b5f1a7463d974b765c06f1c5492edc38cab64382201e1f6f0246e1080e310
 
 name:           json-wsp
 version:        1.1.0
@@ -36,8 +36,42 @@ library
       Paths_json_wsp
   hs-source-dirs:
       src
-  default-extensions: BangPatterns BinaryLiterals ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable EmptyDataDecls ExistentialQuantification FlexibleContexts FlexibleInstances FunctionalDependencies GADTs InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude NumericUnderscores OverloadedStrings PartialTypeSignatures PatternGuards RankNTypes ScopedTypeVariables StandaloneDeriving TupleSections TypeFamilies TypeSynonymInstances ViewPatterns
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+  default-extensions:
+      BangPatterns
+      BinaryLiterals
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveDataTypeable
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveTraversable
+      EmptyDataDecls
+      ExistentialQuantification
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      InstanceSigs
+      KindSignatures
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      NoImplicitPrelude
+      NumericUnderscores
+      OverloadedStrings
+      PartialTypeSignatures
+      PatternGuards
+      RankNTypes
+      ScopedTypeVariables
+      StandaloneDeriving
+      TupleSections
+      TypeFamilies
+      TypeSynonymInstances
+      ViewPatterns
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints -Wunused-packages
   build-depends:
       aeson
     , base >=4.7 && <5

--- a/server/ogmios.cabal
+++ b/server/ogmios.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5e7a2a0fc18edb852d7ce577dd7806fc38279415aae96bcd87ea3c9a831022fa
+-- hash: 3bb7c87b75c0d0934e3dc62e7df2aa7ad57356645b936c9b47e3e6031ce544dc
 
 name:           ogmios
 version:        3.2.0
@@ -62,6 +62,7 @@ library
       Ogmios.Data.Health
       Ogmios.Data.Json
       Ogmios.Data.Json.Allegra
+      Ogmios.Data.Json.Alonzo
       Ogmios.Data.Json.Byron
       Ogmios.Data.Json.Mary
       Ogmios.Data.Json.Prelude
@@ -129,6 +130,7 @@ library
     , cardano-crypto
     , cardano-crypto-class
     , cardano-crypto-wrapper
+    , cardano-ledger-alonzo
     , cardano-ledger-byron
     , cardano-ledger-core
     , cardano-ledger-shelley-ma

--- a/server/ogmios.cabal
+++ b/server/ogmios.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2bcb05f0341461c98f545690d6a8b2d5f947fb5f559b8588ca4be23e0bf2dc9f
+-- hash: 5e7a2a0fc18edb852d7ce577dd7806fc38279415aae96bcd87ea3c9a831022fa
 
 name:           ogmios
 version:        3.2.0
@@ -278,6 +278,7 @@ test-suite unit
     , aeson
     , base >=4.7 && <5
     , cardano-client
+    , cardano-ledger-core
     , cardano-slotting
     , generic-arbitrary
     , hedgehog-quickcheck

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -52,6 +52,7 @@ library:
     - cardano-crypto
     - cardano-crypto-class
     - cardano-crypto-wrapper
+    - cardano-ledger-alonzo
     - cardano-ledger-byron
     - cardano-ledger-core
     - cardano-ledger-shelley-ma

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -121,6 +121,7 @@ tests:
     dependencies:
     - aeson
     - cardano-client
+    - cardano-ledger-core
     - cardano-slotting
     - generic-arbitrary
     - hedgehog-quickcheck

--- a/server/resolver.yaml
+++ b/server/resolver.yaml
@@ -16,12 +16,21 @@ packages:
 - binary-0.8.7.0 # 0.8.8.0 on LTS 17.6
 - Cabal-3.2.1.0
 - canonical-json-0.6.0.0
+- composition-prelude-3.0.0.2
+- constraints-extras-0.3.1.0
 - containers-0.5.11.0 # 0.6.2.1 on LTS 17.6
+- dependent-map-0.4.0.0
+- dependent-sum-0.6.2.0
+- dependent-sum-template-0.1.0.3
 - dns-3.0.4 # 4.0.1 on LTS 17.6
 - gray-code-0.3.1
+- indexed-traversable-instances-0.1
+- lazy-search-0.1.2.1
+- lazysmallcheck-0.6
 - libsystemd-journal-1.4.4
 - markov-chain-usage-model-0.0.0
 - micro-recursion-schemes-5.0.2.2
+- monoidal-containers-0.6.0.1
 - moo-1.2
 - network-3.1.2.1 # 3.1.1.1 on LTS 17.6
 - nothunks-0.1.2
@@ -29,30 +38,36 @@ packages:
 - partial-order-0.2.0.0
 - quickcheck-state-machine-0.7.0
 - regex-posix-clib-2.7
+- size-based-0.1.2.0
 - statistics-linreg-0.3
+- Stream-0.4.7.2
 - streaming-binary-0.2.2.0
 - text-1.2.4.0 # 1.2.4.1 on LTS 17.6
 - transformers-except-0.1.1
 - Unique-0.4.7.6
 - Win32-2.6.2.0
+- witherable-0.4.1
+
 
 - git: https://github.com/input-output-hk/cardano-base
-  commit: 47db5b818ca4fa051f2e44cdf5e7c5c18c1fb0bf
+  commit: a715c7f420770b70bbe95ca51d3dec83866cb1bd
   subdirs:
   - binary
   - binary/test
   - cardano-crypto-class
-  - cardano-crypto-tests
   - cardano-crypto-praos
+  - cardano-crypto-tests
   - slotting
   - strict-containers
 
 - git: https://github.com/input-output-hk/cardano-crypto
-  commit: f73079303f663e028288f9f4a9e08bcca39a923e
+  commit: ce8f1934e4b6252084710975bd9bbc0a4648ece4
 
 - git: https://github.com/input-output-hk/cardano-ledger-specs
-  commit: e8f19bcc9c8f405131cb95ca6ada26b2b4eac638
+  commit: 41b02e51d3e0a4826264fc4ae595a9dd6a7d8849
   subdirs:
+  - alonzo/impl
+  - alonzo/test
   - byron/chain/executable-spec
   - byron/crypto
   - byron/crypto/test
@@ -69,13 +84,13 @@ packages:
   - shelley-ma/shelley-ma-test
 
 - git: https://github.com/input-output-hk/cardano-node
-  commit: 8fe46140a52810b6ca456be01d652ca08fe730bf
+  commit: b83e4025785be16cb5ee5231a6e9939d93564b40
   subdirs:
     - cardano-api
     - cardano-config
 
 - git: https://github.com/input-output-hk/cardano-prelude
-  commit: bb4ed71ba8e587f672d06edf9d2e376f4b055555
+  commit: fd773f7a58412131512b9f694ab95653ac430852
   subdirs:
   - cardano-prelude
   - cardano-prelude-test
@@ -105,7 +120,7 @@ packages:
   - tracer-transformers
 
 - git: https://github.com/input-output-hk/ouroboros-network
-  commit: 9b279c7548ee549e1ed755cd1acb69b6e69d0c7b
+  commit: 8bbded8a3a6e967ce67fbcaf50579d3719e52bef
   subdirs:
     - io-sim
     - io-sim-classes
@@ -125,8 +140,16 @@ packages:
     - typed-protocols
     - typed-protocols-examples
 
+- git: https://github.com/input-output-hk/plutus
+  commit: 530d3f7940319788a49c7ecb017f8366994990b0
+  subdirs:
+    - plutus-core
+    - plutus-ledger-api
+    - plutus-tx
+    - prettyprinter-configurable
+
 - git: https://github.com/KtorZ/wai-routes
   commit: d74b39683792649c01113f40bf57724dcf95c96a
 
 - git: https://github.com/input-output-hk/Win32-network
-  commit: 94153b676617f8f33abe8d8182c37377d2784bd1
+  commit: 82f4afb8c240b8446a1db6c6b50901a42028ce0f

--- a/server/src/Ogmios/App/Health.hs
+++ b/server/src/Ogmios/App/Health.hs
@@ -97,7 +97,7 @@ import Ouroboros.Network.Protocol.LocalTxSubmission.Client
     ( LocalTxSubmissionClient (..) )
 
 import qualified Ouroboros.Consensus.HardFork.Combinator as LSQ
-import qualified Ouroboros.Consensus.Shelley.Ledger.Query as Ledger
+import qualified Ouroboros.Consensus.Ledger.Query as Ledger
 import qualified Ouroboros.Network.Protocol.LocalStateQuery.Client as LSQ
 
 --
@@ -302,7 +302,8 @@ newTimeInterpreterClient = do
         -> m (LSQ.ClientStAcquired block (Point block) (Ledger.Query block) m ())
         -> LSQ.ClientStAcquired block (Point block) (Ledger.Query block) m ()
     clientStQuerySlotTime notifyResult tip continue =
-        LSQ.SendMsgQuery (LSQ.QueryHardFork LSQ.GetInterpreter) $ LSQ.ClientStQuerying
+        let query = Ledger.BlockQuery $ LSQ.QueryHardFork LSQ.GetInterpreter in
+        LSQ.SendMsgQuery query $ LSQ.ClientStQuerying
             { LSQ.recvMsgResult = \interpreter -> do
                 let slot = case tip of
                         TipGenesis -> 0
@@ -325,7 +326,8 @@ newTimeInterpreterClient = do
         -> m (LSQ.ClientStAcquired block (Point block) (Ledger.Query block) m ())
         -> LSQ.ClientStAcquired block (Point block) (Ledger.Query block) m ()
     clientStQueryCurrentEra notifyResult continue =
-        LSQ.SendMsgQuery (LSQ.QueryHardFork LSQ.GetCurrentEra) $ LSQ.ClientStQuerying
+        let query = Ledger.BlockQuery $ LSQ.QueryHardFork LSQ.GetCurrentEra in
+        LSQ.SendMsgQuery query $ LSQ.ClientStQuerying
             { LSQ.recvMsgResult = \eraIndex -> do
                 notifyResult $ case eraIndexToInt eraIndex of
                     0 -> Byron

--- a/server/src/Ogmios/Data/Json.hs
+++ b/server/src/Ogmios/Data/Json.hs
@@ -66,6 +66,7 @@ import qualified Codec.CBOR.Write as Cbor
 import qualified Data.Aeson as Json
 import qualified Data.Aeson.Types as Json
 import qualified Ogmios.Data.Json.Allegra as Allegra
+import qualified Ogmios.Data.Json.Alonzo as Alonzo
 import qualified Ogmios.Data.Json.Byron as Byron
 import qualified Ogmios.Data.Json.Mary as Mary
 import qualified Ogmios.Data.Json.Query as Query
@@ -118,9 +119,9 @@ encodeBlock mode = \case
           , Mary.encodeMaryBlock mode blk
           )
         ]
-    BlockAlonzo _blk -> encodeObject
+    BlockAlonzo blk -> encodeObject
         [ ( "alonzo"
-          , error "FIXME: Alonzo.encodeAlonzoBlock mode blk"
+          , Alonzo.encodeAlonzoBlock mode blk
           )
         ]
 

--- a/server/src/Ogmios/Data/Json.hs
+++ b/server/src/Ogmios/Data/Json.hs
@@ -118,6 +118,11 @@ encodeBlock mode = \case
           , Mary.encodeMaryBlock mode blk
           )
         ]
+    BlockAlonzo _blk -> encodeObject
+        [ ( "alonzo"
+          , error "FIXME: Alonzo.encodeAlonzoBlock mode blk"
+          )
+        ]
 
 encodeHardForkApplyTxErr
     :: Crypto crypto
@@ -132,6 +137,8 @@ encodeHardForkApplyTxErr = \case
         encodeList Allegra.encodeLedgerFailure xs
     ApplyTxErrMary (ApplyTxError xs) ->
         encodeList Mary.encodeLedgerFailure xs
+    ApplyTxErrAlonzo (ApplyTxError xs) ->
+        encodeList (error "FIXME: Alonzo.encodeLedgerFailure") xs
     ApplyTxErrWrongEra e ->
         encodeEraMismatch e
 

--- a/server/src/Ogmios/Data/Json.hs
+++ b/server/src/Ogmios/Data/Json.hs
@@ -106,22 +106,22 @@ encodeBlock mode = \case
         ]
     BlockShelley blk -> encodeObject
         [ ( "shelley"
-          , Shelley.encodeShelleyBlock mode blk
+          , Shelley.encodeBlock mode blk
           )
         ]
     BlockAllegra blk -> encodeObject
         [ ( "allegra"
-          , Allegra.encodeAllegraBlock mode blk
+          , Allegra.encodeBlock mode blk
           )
         ]
     BlockMary blk -> encodeObject
         [ ( "mary"
-          , Mary.encodeMaryBlock mode blk
+          , Mary.encodeBlock mode blk
           )
         ]
     BlockAlonzo blk -> encodeObject
         [ ( "alonzo"
-          , Alonzo.encodeAlonzoBlock mode blk
+          , Alonzo.encodeBlock mode blk
           )
         ]
 
@@ -139,7 +139,7 @@ encodeHardForkApplyTxErr = \case
     ApplyTxErrMary (ApplyTxError xs) ->
         encodeList Mary.encodeLedgerFailure xs
     ApplyTxErrAlonzo (ApplyTxError xs) ->
-        encodeList (error "FIXME: Alonzo.encodeLedgerFailure") xs
+        encodeList Alonzo.encodeLedgerFailure xs
     ApplyTxErrWrongEra e ->
         encodeEraMismatch e
 

--- a/server/src/Ogmios/Data/Json/Allegra.hs
+++ b/server/src/Ogmios/Data/Json/Allegra.hs
@@ -16,23 +16,23 @@ import Ouroboros.Consensus.Cardano.Block
     ( AllegraEra )
 import Ouroboros.Consensus.Shelley.Ledger.Block
     ( ShelleyBlock (..) )
-import Shelley.Spec.Ledger.BaseTypes
-    ( StrictMaybe (..) )
 
 import qualified Ogmios.Data.Json.Shelley as Shelley
 
-import qualified Cardano.Ledger.AuxiliaryData as MA
-import qualified Cardano.Ledger.Core as Sh.Core
+import qualified Cardano.Ledger.AuxiliaryData as Aux
+import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Era as Era
-import qualified Cardano.Ledger.ShelleyMA.AuxiliaryData as MA
-import qualified Cardano.Ledger.ShelleyMA.Rules.Utxo as MA
-import qualified Cardano.Ledger.ShelleyMA.Timelocks as MA
-import qualified Cardano.Ledger.ShelleyMA.TxBody as MA
+
 import qualified Shelley.Spec.Ledger.BlockChain as Sh
 import qualified Shelley.Spec.Ledger.PParams as Sh
 import qualified Shelley.Spec.Ledger.STS.Ledger as Sh
 import qualified Shelley.Spec.Ledger.Tx as Sh
 import qualified Shelley.Spec.Ledger.UTxO as Sh
+
+import qualified Cardano.Ledger.ShelleyMA.AuxiliaryData as MA
+import qualified Cardano.Ledger.ShelleyMA.Rules.Utxo as MA
+import qualified Cardano.Ledger.ShelleyMA.Timelocks as MA
+import qualified Cardano.Ledger.ShelleyMA.TxBody as MA
 
 --
 -- Encoders
@@ -46,8 +46,8 @@ encodeAuxiliaryData (MA.AuxiliaryData blob scripts) = encodeObject
     [ ( "blob"
       , Shelley.encodeMetadataBlob blob
       )
-    , ( "scriptPreImages"
-      , encodeFoldable encodeTimelock scripts
+    , ( "scripts"
+      , encodeFoldable encodeScript scripts
       )
     ]
 
@@ -87,7 +87,7 @@ encodePParams' =
     Shelley.encodePParams'
 
 encodeProposedPPUpdates
-    :: (Sh.Core.PParamsDelta era ~ Sh.PParamsUpdate era)
+    :: (Core.PParamsDelta era ~ Sh.PParamsUpdate era)
     => Sh.ProposedPPUpdates era
     -> Json
 encodeProposedPPUpdates =
@@ -145,7 +145,7 @@ encodeTx mode x = encodeObjectWithMode mode
       )
     ]
   where
-    adHash :: MA.TxBody era -> StrictMaybe (MA.AuxiliaryDataHash (Era.Crypto era))
+    adHash :: MA.TxBody era -> StrictMaybe (Aux.AuxiliaryDataHash (Era.Crypto era))
     adHash = getField @"adHash"
 
 encodeTxBody

--- a/server/src/Ogmios/Data/Json/Allegra.hs
+++ b/server/src/Ogmios/Data/Json/Allegra.hs
@@ -296,7 +296,7 @@ encodeWitnessSet x = encodeObject
       , encodeFoldable Shelley.encodeWitVKey (Sh.addrWits x)
       )
     , ( "scripts"
-      , encodeMap Shelley.stringifyScriptHash encodeTimelock (Sh.scriptWits x)
+      , encodeMap Shelley.stringifyScriptHash encodeScript (Sh.scriptWits x)
       )
     , ( "bootstrap"
       , encodeFoldable Shelley.encodeBootstrapWitness (Sh.bootWits x)

--- a/server/src/Ogmios/Data/Json/Allegra.hs
+++ b/server/src/Ogmios/Data/Json/Allegra.hs
@@ -93,6 +93,13 @@ encodeProposedPPUpdates
 encodeProposedPPUpdates =
     Shelley.encodeProposedPPUpdates
 
+encodeScript
+    :: Crypto crypto
+    => MA.Timelock crypto
+    -> Json
+encodeScript timelock = encodeObject
+    [ ( "native", encodeTimelock timelock ) ]
+
 encodeTimelock
     :: Crypto crypto
     => MA.Timelock crypto
@@ -277,10 +284,10 @@ encodeWitnessSet
     => Sh.WitnessSet (AllegraEra crypto)
     -> Json
 encodeWitnessSet x = encodeObject
-    [ ( "address"
+    [ ( "signatures"
       , encodeFoldable Shelley.encodeWitVKey (Sh.addrWits x)
       )
-    , ( "script"
+    , ( "scripts"
       , encodeMap Shelley.stringifyScriptHash encodeTimelock (Sh.scriptWits x)
       )
     , ( "bootstrap"

--- a/server/src/Ogmios/Data/Json/Allegra.hs
+++ b/server/src/Ogmios/Data/Json/Allegra.hs
@@ -22,8 +22,8 @@ import Shelley.Spec.Ledger.BaseTypes
 import qualified Ogmios.Data.Json.Shelley as Shelley
 
 import qualified Cardano.Ledger.AuxiliaryData as MA
+import qualified Cardano.Ledger.Core as Sh.Core
 import qualified Cardano.Ledger.Era as Era
-import qualified Cardano.Ledger.Shelley.Constraints as Sh
 import qualified Cardano.Ledger.ShelleyMA.AuxiliaryData as MA
 import qualified Cardano.Ledger.ShelleyMA.Rules.Utxo as MA
 import qualified Cardano.Ledger.ShelleyMA.Timelocks as MA
@@ -87,7 +87,7 @@ encodePParams' =
     Shelley.encodePParams'
 
 encodeProposedPPUpdates
-    :: (Sh.PParamsDelta era ~ Sh.PParamsUpdate era)
+    :: (Sh.Core.PParamsDelta era ~ Sh.PParamsUpdate era)
     => Sh.ProposedPPUpdates era
     -> Json
 encodeProposedPPUpdates =

--- a/server/src/Ogmios/Data/Json/Allegra.hs
+++ b/server/src/Ogmios/Data/Json/Allegra.hs
@@ -166,7 +166,7 @@ encodeTxBody (MA.TxBody inps outs certs wdrls fee validity updates _ _) = encode
       , Shelley.encodeWdrl wdrls
       )
     , ( "fee"
-      , Shelley.encodeCoin fee
+      , encodeCoin fee
       )
     , ( "validityInterval"
       , encodeValidityInterval validity
@@ -221,16 +221,16 @@ encodeUtxoFailure = \case
     MA.FeeTooSmallUTxO required actual ->
         encodeObject
             [ ( "feeTooSmall", encodeObject
-                [ ( "requiredFee", Shelley.encodeCoin required )
-                , ( "actualFee", Shelley.encodeCoin actual )
+                [ ( "requiredFee", encodeCoin required )
+                , ( "actualFee", encodeCoin actual )
                 ]
               )
             ]
     MA.ValueNotConservedUTxO consumed produced ->
         encodeObject
             [ ( "valueNotConserved", encodeObject
-                [ ( "consumed", Shelley.encodeCoin consumed )
-                , ( "produced", Shelley.encodeCoin produced )
+                [ ( "consumed", encodeCoin consumed )
+                , ( "produced", encodeCoin produced )
                 ]
               )
             ]

--- a/server/src/Ogmios/Data/Json/Alonzo.hs
+++ b/server/src/Ogmios/Data/Json/Alonzo.hs
@@ -20,8 +20,6 @@ import Ouroboros.Consensus.Cardano.Block
     ( AlonzoEra )
 import Ouroboros.Consensus.Shelley.Ledger.Block
     ( ShelleyBlock (..) )
-import Shelley.Spec.Ledger.BaseTypes
-    ( StrictMaybe (..) )
 
 import qualified Data.Map.Strict as Map
 
@@ -33,10 +31,10 @@ import qualified Cardano.Crypto.Hash.Class as CC
 import qualified Cardano.Ledger.Era as Era
 import qualified Cardano.Ledger.SafeHash as SafeHash
 
-import qualified Shelley.Spec.Ledger.API as Spec
-import qualified Shelley.Spec.Ledger.PParams as Spec
-import qualified Shelley.Spec.Ledger.STS.Ledger as Spec
-import qualified Shelley.Spec.Ledger.UTxO as Spec
+import qualified Shelley.Spec.Ledger.API as Sh
+import qualified Shelley.Spec.Ledger.PParams as Sh
+import qualified Shelley.Spec.Ledger.STS.Ledger as Sh
+import qualified Shelley.Spec.Ledger.UTxO as Sh
 
 import qualified Cardano.Ledger.Alonzo.Data as Al
 import qualified Cardano.Ledger.Alonzo.Language as Al
@@ -113,7 +111,7 @@ encodeBlock
     => SerializationMode
     -> ShelleyBlock (AlonzoEra crypto)
     -> Json
-encodeBlock mode (ShelleyBlock (Spec.Block blkHeader txs) headerHash) =
+encodeBlock mode (ShelleyBlock (Sh.Block blkHeader txs) headerHash) =
     encodeObject
     [ ( "body"
       , encodeFoldable (encodeTx mode) (Al.txSeqTxns txs)
@@ -192,16 +190,16 @@ encodeLanguage = \case
 
 encodeLedgerFailure
     :: Crypto crypto
-    => Spec.LedgerPredicateFailure (AlonzoEra crypto)
+    => Sh.LedgerPredicateFailure (AlonzoEra crypto)
     -> Json
 encodeLedgerFailure = \case
-    Spec.UtxowFailure e ->
+    Sh.UtxowFailure e ->
         encodeAlonzoPredFail e
-    Spec.DelegsFailure e ->
+    Sh.DelegsFailure e ->
         Shelley.encodeDelegsFailure e
 
 encodePParams'
-    :: (forall a. (a -> Json) -> Spec.HKD f a -> Json)
+    :: (forall a. (a -> Json) -> Sh.HKD f a -> Json)
     -> Al.PParams' f era
     -> Json
 encodePParams' encodeF x = encodeObject
@@ -288,9 +286,9 @@ encodePrices prices =  encodeObject
     ]
 
 encodeProposedPPUpdates
-    :: Spec.ProposedPPUpdates (AlonzoEra crypto)
+    :: Sh.ProposedPPUpdates (AlonzoEra crypto)
     -> Json
-encodeProposedPPUpdates (Spec.ProposedPPUpdates m) =
+encodeProposedPPUpdates (Sh.ProposedPPUpdates m) =
     encodeMap Shelley.stringifyKeyHash (encodePParams' encodeStrictMaybe) m
 
 encodeRedeemers
@@ -345,7 +343,7 @@ encodeTx
     -> Json
 encodeTx mode x = encodeObjectWithMode mode
     [ ( "id"
-      , Shelley.encodeTxId (Spec.txid @(AlonzoEra crypto) (Al.body x))
+      , Shelley.encodeTxId (Sh.txid @(AlonzoEra crypto) (Al.body x))
       )
     , ( "body"
       , encodeTxBody (Al.body x)
@@ -428,9 +426,9 @@ encodeTxOut (Al.TxOut addr value datum) = encodeObject
     ]
 
 encodeUpdate
-    :: Spec.Update (AlonzoEra crypto)
+    :: Sh.Update (AlonzoEra crypto)
     -> Json
-encodeUpdate (Spec.Update update epoch) = encodeObject
+encodeUpdate (Sh.Update update epoch) = encodeObject
     [ ( "proposal"
       , encodeProposedPPUpdates update
       )
@@ -441,10 +439,10 @@ encodeUpdate (Spec.Update update epoch) = encodeObject
 
 encodeUtxo
     :: Crypto crypto
-    => Spec.UTxO (AlonzoEra crypto)
+    => Sh.UTxO (AlonzoEra crypto)
     -> Json
 encodeUtxo =
-    encodeList id . Map.foldrWithKey (\i o -> (:) (encodeIO i o)) [] . Spec.unUTxO
+    encodeList id . Map.foldrWithKey (\i o -> (:) (encodeIO i o)) [] . Sh.unUTxO
   where
     encodeIO = curry (encode2Tuple Shelley.encodeTxIn encodeTxOut)
 

--- a/server/src/Ogmios/Data/Json/Alonzo.hs
+++ b/server/src/Ogmios/Data/Json/Alonzo.hs
@@ -27,6 +27,7 @@ import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as Map
 
 import qualified Ogmios.Data.Json.Allegra as Allegra
+import qualified Ogmios.Data.Json.Mary as Mary
 import qualified Ogmios.Data.Json.Shelley as Shelley
 
 import qualified Cardano.Crypto.Hash.Class as CC
@@ -35,6 +36,7 @@ import qualified Cardano.Ledger.SafeHash as SafeHash
 
 import qualified Shelley.Spec.Ledger.API as Spec
 import qualified Shelley.Spec.Ledger.BlockChain as Spec
+import qualified Shelley.Spec.Ledger.PParams as Spec
 import qualified Shelley.Spec.Ledger.Tx as Spec
 import qualified Shelley.Spec.Ledger.UTxO as Spec
 
@@ -93,6 +95,12 @@ encodeAuxiliaryData (Al.AuxiliaryData blob scripts datums) = encodeObject
       )
     ]
 
+encodeCostModel
+    :: Al.CostModel
+    -> Json
+encodeCostModel (Al.CostModel model) =
+    encodeMap id encodeInteger model
+
 encodeData
     :: Al.Data era
     -> Json
@@ -101,11 +109,121 @@ encodeData (Al.DataConstr datum) =
     -- to strip away the extra CBOR wrapping this if any.
     encodeShortByteString encodeByteStringBase64 (memobytes datum)
 
-encodeRedeemers
-    :: Al.Redeemers era
+encodeExUnits
+    :: Al.ExUnits
     -> Json
-encodeRedeemers =
-    error "FIXME: encodeRedeemers"
+encodeExUnits units =  encodeObject
+    [ ( "memory", encodeWord64 (Al.exUnitsMem units) )
+    , ( "steps", encodeWord64 (Al.exUnitsSteps units) )
+    ]
+
+encodePParams'
+    :: (forall a. (a -> Json) -> Spec.HKD f a -> Json)
+    -> Al.PParams' f era
+    -> Json
+encodePParams' encodeF x = encodeObject
+    [ ( "minFeeCoefficient"
+      , encodeF encodeNatural (Al._minfeeA x)
+      )
+    , ( "minFeeConstant"
+      , encodeF encodeNatural (Al._minfeeB x)
+      )
+    , ( "maxBlockBodySize"
+      , encodeF encodeNatural (Al._maxBBSize x)
+      )
+    , ( "maxBlockHeaderSize"
+      , encodeF encodeNatural (Al._maxBHSize x)
+      )
+    , ( "maxTxSize"
+      , encodeF encodeNatural (Al._maxTxSize x)
+      )
+    , ( "stakeKeyDeposit"
+      , encodeF Shelley.encodeCoin (Al._keyDeposit x)
+      )
+    , ( "poolDeposit"
+      , encodeF Shelley.encodeCoin (Al._poolDeposit x)
+      )
+    , ( "poolRetirementEpochBound"
+      , encodeF encodeEpochNo (Al._eMax x)
+      )
+    , ( "desiredNumberOfPools"
+      , encodeF encodeNatural (Al._nOpt x)
+      )
+    , ( "poolInfluence"
+      , encodeF encodeRational (Al._a0 x)
+      )
+    , ( "monetaryExpansion"
+      , encodeF encodeUnitInterval (Al._rho x)
+      )
+    , ( "treasuryExpansion"
+      , encodeF encodeUnitInterval (Al._tau x)
+      )
+    , ( "decentralizationParameter"
+      , encodeF encodeUnitInterval (Al._d x)
+      )
+    , ( "extraEntropy"
+      , encodeF Shelley.encodeNonce (Al._extraEntropy x)
+      )
+    , ( "protocolVersion"
+      , encodeF Shelley.encodeProtVer (Al._protocolVersion x)
+      )
+    , ( "minPoolCost"
+      , encodeF Shelley.encodeCoin (Al._minPoolCost x)
+      )
+    , ( "adaPerUtxoWord"
+      , encodeF Shelley.encodeCoin (Al._adaPerUTxOWord x)
+      )
+    , ( "costModels"
+      , encodeF (encodeMap stringifyLanguage encodeCostModel) (Al._costmdls x)
+      )
+    , ( "prices"
+      , encodeF encodePrices (Al._prices x)
+      )
+    , ( "maxExecutionUnitsPerTransaction"
+      , encodeF encodeExUnits (Al._maxTxExUnits x)
+      )
+    , ( "maxExecutionUnitsPerBlock"
+      , encodeF encodeExUnits (Al._maxBlockExUnits x)
+      )
+    , ( "maxValueSize"
+      , encodeF encodeNatural (Al._maxValSize x)
+      )
+    , ( "collateralPercentage"
+      , encodeF encodeNatural (Al._collateralPercentage x)
+      )
+    , ( "maxCollateralInputs"
+      , encodeF encodeNatural (Al._maxCollateralInputs x)
+      )
+    ]
+
+encodePrices
+    :: Al.Prices
+    -> Json
+encodePrices prices =  encodeObject
+    [ ( "memory", Shelley.encodeCoin (Al.prMem prices) )
+    , ( "steps", Shelley.encodeCoin (Al.prSteps prices) )
+    ]
+
+encodeProposedPPUpdates
+    :: Spec.ProposedPPUpdates (AlonzoEra crypto)
+    -> Json
+encodeProposedPPUpdates (Spec.ProposedPPUpdates m) =
+    encodeMap Shelley.stringifyKeyHash (encodePParams' encodeStrictMaybe) m
+
+encodeRedeemers
+    :: Crypto crypto
+    => Al.Redeemers (AlonzoEra crypto)
+    -> Json
+encodeRedeemers (Al.Redeemers redeemers) =
+    encodeMap stringifyRdmrPtr encodeDataAndUnits redeemers
+  where
+    encodeDataAndUnits
+        :: (Al.Data era, Al.ExUnits)
+        -> Json
+    encodeDataAndUnits (redeemer, units) = encodeObject
+        [ ( "redeemer", encodeData redeemer )
+        , ( "executionUnits", encodeExUnits units )
+        ]
 
 encodeScript
     :: Crypto crypto
@@ -132,18 +250,18 @@ encodeTx mode x = encodeObjectWithMode mode
     [ ( "id"
       , Shelley.encodeTxId (Spec.txid @(AlonzoEra crypto) (Al.body x))
       )
-      , ( "body"
-        , encodeTxBody (Al.body x)
-        )
-      , ( "metadata", encodeObject
-          [ ( "hash"
-            , encodeStrictMaybe Shelley.encodeAuxiliaryDataHash (adHash (Al.body x))
-            )
-          , ( "body"
-            , encodeStrictMaybe encodeAuxiliaryData (Al.auxiliaryData x)
-            )
-          ]
-        )
+    , ( "body"
+      , encodeTxBody (Al.body x)
+      )
+    , ( "metadata", encodeObject
+        [ ( "hash"
+          , encodeStrictMaybe Shelley.encodeAuxiliaryDataHash (adHash (Al.body x))
+          )
+        , ( "body"
+          , encodeStrictMaybe encodeAuxiliaryData (Al.auxiliaryData x)
+          )
+        ]
+      )
     ]
     [ ( "witness"
       , encodeWitnessSet (Al.wits x)
@@ -157,8 +275,72 @@ encodeTxBody
     :: Crypto crypto
     => Al.TxBody (AlonzoEra crypto)
     -> Json
-encodeTxBody =
-    error "FIXME: encodeTxBody"
+encodeTxBody x = encodeObject
+    [ ( "inputs"
+      , encodeFoldable Shelley.encodeTxIn (Al.inputs x)
+      )
+    , ( "collateral"
+      , encodeFoldable Shelley.encodeTxIn (Al.collateral x)
+      )
+    , ( "outputs"
+      , encodeFoldable encodeTxOut (Al.outputs x)
+      )
+    , ( "certificates"
+      , encodeFoldable Shelley.encodeDCert (Al.txcerts x)
+      )
+    , ( "withdrawals"
+      , Shelley.encodeWdrl (Al.txwdrls x)
+      )
+    , ( "fee"
+      , Shelley.encodeCoin (Al.txfee x)
+      )
+    , ( "validityInterval"
+      , Allegra.encodeValidityInterval (Al.txvldt x)
+      )
+    , ( "update"
+      , encodeStrictMaybe encodeUpdate (Al.txUpdates x)
+      )
+    , ( "mint"
+      , Mary.encodeValue (Al.mint x)
+      )
+    , ( "network"
+      , encodeStrictMaybe Shelley.encodeNetwork (Al.txnetworkid x)
+      )
+    , ( "requiredExtraData"
+      , encodeStrictMaybe (Shelley.encodeHash . SafeHash.extractHash) (Al.wppHash x)
+      )
+    , ( "requiredExtraSignatures"
+      , encodeFoldable Shelley.encodeKeyHash (Al.reqSignerHashes x)
+      )
+    ]
+
+encodeTxOut
+    :: Crypto crypto
+    => Al.TxOut (AlonzoEra crypto)
+    -> Json
+encodeTxOut (Al.TxOut addr value datum) = encodeObject
+    [ ( "address"
+      , Shelley.encodeAddress addr
+      )
+    , ( "value"
+      , Mary.encodeValue value
+      )
+    , ( "datum"
+      , encodeStrictMaybe (Shelley.encodeHash . SafeHash.extractHash) datum
+      )
+    ]
+
+encodeUpdate
+    :: Spec.Update (AlonzoEra crypto)
+    -> Json
+encodeUpdate (Spec.Update update epoch) = encodeObject
+    [ ( "proposal"
+      , encodeProposedPPUpdates update
+      )
+    , ( "epoch"
+      , encodeEpochNo epoch
+      )
+    ]
 
 encodeWitnessSet
     :: Crypto crypto
@@ -191,3 +373,24 @@ stringifyDataHash
     -> Text
 stringifyDataHash (SafeHash.extractHash -> (CC.UnsafeHash h)) =
     encodeBase16 (fromShort h)
+
+stringifyLanguage
+    :: Al.Language
+    -> Text
+stringifyLanguage = \case
+    Al.PlutusV1 -> "plutus:v1"
+
+stringifyRdmrPtr
+    :: Al.RdmrPtr
+    -> Text
+stringifyRdmrPtr (Al.RdmrPtr tag ptr) =
+    stringifyTag tag <> ":" <> show ptr
+  where
+    stringifyTag
+        :: Al.Tag
+        -> Text
+    stringifyTag = \case
+        Al.Spend -> "utxo"
+        Al.Mint -> "mint"
+        Al.Cert -> "certificate"
+        Al.Rewrd -> "withdrawal"

--- a/server/src/Ogmios/Data/Json/Alonzo.hs
+++ b/server/src/Ogmios/Data/Json/Alonzo.hs
@@ -1,0 +1,193 @@
+--  This Source Code Form is subject to the terms of the Mozilla Public
+--  License, v. 2.0. If a copy of the MPL was not distributed with this
+--  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+{-# LANGUAGE TypeApplications #-}
+
+module Ogmios.Data.Json.Alonzo where
+
+import Ogmios.Data.Json.Prelude
+
+import Cardano.Ledger.Crypto
+    ( Crypto )
+import Data.ByteString.Base16
+    ( encodeBase16 )
+import Data.MemoBytes
+    ( memobytes )
+import GHC.Records
+    ( getField )
+import Ouroboros.Consensus.Cardano.Block
+    ( AlonzoEra )
+import Ouroboros.Consensus.Shelley.Ledger.Block
+    ( ShelleyBlock (..) )
+import Shelley.Spec.Ledger.BaseTypes
+    ( StrictMaybe (..) )
+
+import qualified Data.ByteString as BS
+import qualified Data.Map.Strict as Map
+
+import qualified Ogmios.Data.Json.Allegra as Allegra
+import qualified Ogmios.Data.Json.Shelley as Shelley
+
+import qualified Cardano.Crypto.Hash.Class as CC
+import qualified Cardano.Ledger.Era as Era
+import qualified Cardano.Ledger.SafeHash as SafeHash
+
+import qualified Shelley.Spec.Ledger.API as Spec
+import qualified Shelley.Spec.Ledger.BlockChain as Spec
+import qualified Shelley.Spec.Ledger.Tx as Spec
+import qualified Shelley.Spec.Ledger.UTxO as Spec
+
+import qualified Cardano.Ledger.Alonzo.Data as Al
+import qualified Cardano.Ledger.Alonzo.Language as Al
+import qualified Cardano.Ledger.Alonzo.PlutusScriptApi as Al
+import qualified Cardano.Ledger.Alonzo.PParams as Al
+import qualified Cardano.Ledger.Alonzo.Rules.Bbody as Al
+import qualified Cardano.Ledger.Alonzo.Rules.Ledger as Al
+import qualified Cardano.Ledger.Alonzo.Rules.Utxo as Al
+import qualified Cardano.Ledger.Alonzo.Rules.Utxos as Al
+import qualified Cardano.Ledger.Alonzo.Rules.Utxow as Al
+import qualified Cardano.Ledger.Alonzo.Scripts as Al
+import qualified Cardano.Ledger.Alonzo.Translation as Al
+import qualified Cardano.Ledger.Alonzo.Tx as Al
+import qualified Cardano.Ledger.Alonzo.TxBody as Al
+import qualified Cardano.Ledger.Alonzo.TxInfo as Al
+import qualified Cardano.Ledger.Alonzo.TxSeq as Al
+import qualified Cardano.Ledger.Alonzo.TxWitness as Al
+
+--
+-- Encoders
+--
+
+encodeAlonzoBlock
+    :: Crypto crypto
+    => SerializationMode
+    -> ShelleyBlock (AlonzoEra crypto)
+    -> Json
+encodeAlonzoBlock mode (ShelleyBlock (Spec.Block blkHeader txs) headerHash) =
+    encodeObject
+    [ ( "body"
+      , encodeFoldable (encodeTx mode) (Al.txSeqTxns txs)
+      )
+    , ( "header"
+      , Shelley.encodeBHeader mode blkHeader
+      )
+    , ( "headerHash"
+      , Shelley.encodeShelleyHash headerHash
+      )
+    ]
+
+encodeAuxiliaryData
+    :: Crypto crypto
+    => Al.AuxiliaryData (AlonzoEra crypto)
+    -> Json
+encodeAuxiliaryData (Al.AuxiliaryData blob scripts datums) = encodeObject
+    [ ( "blob"
+      , Shelley.encodeMetadataBlob blob
+      )
+    , ( "scripts"
+      , encodeFoldable encodeScript scripts
+      )
+    , ( "datums"
+      , encodeFoldable encodeData datums
+      )
+    ]
+
+encodeData
+    :: Al.Data era
+    -> Json
+encodeData (Al.DataConstr datum) =
+    -- TODO: Check whether 'memobytes' really is what we want here. Might be good
+    -- to strip away the extra CBOR wrapping this if any.
+    encodeShortByteString encodeByteStringBase64 (memobytes datum)
+
+encodeRedeemers
+    :: Al.Redeemers era
+    -> Json
+encodeRedeemers =
+    error "FIXME: encodeRedeemers"
+
+encodeScript
+    :: Crypto crypto
+    => Al.Script (AlonzoEra crypto)
+    -> Json
+encodeScript = \case
+    Al.TimelockScript nativeScript -> encodeObject
+        [ ( "native"
+          , Allegra.encodeTimelock nativeScript
+          )
+        ]
+    Al.PlutusScript serializedScript -> encodeObject
+        [ ( "plutus"
+          , encodeShortByteString encodeByteStringBase64 serializedScript
+          )
+        ]
+
+encodeTx
+    :: forall crypto. Crypto crypto
+    => SerializationMode
+    -> Al.ValidatedTx (AlonzoEra crypto)
+    -> Json
+encodeTx mode x = encodeObjectWithMode mode
+    [ ( "id"
+      , Shelley.encodeTxId (Spec.txid @(AlonzoEra crypto) (Al.body x))
+      )
+      , ( "body"
+        , encodeTxBody (Al.body x)
+        )
+      , ( "metadata", encodeObject
+          [ ( "hash"
+            , encodeStrictMaybe Shelley.encodeAuxiliaryDataHash (adHash (Al.body x))
+            )
+          , ( "body"
+            , encodeStrictMaybe encodeAuxiliaryData (Al.auxiliaryData x)
+            )
+          ]
+        )
+    ]
+    [ ( "witness"
+      , encodeWitnessSet (Al.wits x)
+      )
+    ]
+  where
+    adHash :: Al.TxBody era -> StrictMaybe (Al.AuxiliaryDataHash (Era.Crypto era))
+    adHash = getField @"adHash"
+
+encodeTxBody
+    :: Crypto crypto
+    => Al.TxBody (AlonzoEra crypto)
+    -> Json
+encodeTxBody =
+    error "FIXME: encodeTxBody"
+
+encodeWitnessSet
+    :: Crypto crypto
+    => Al.TxWitness (AlonzoEra crypto)
+    -> Json
+encodeWitnessSet x = encodeObject
+    [ ( "signatures"
+      , encodeFoldable Shelley.encodeWitVKey (Al.txwitsVKey x)
+      )
+    , ( "scripts"
+      , encodeMap Shelley.stringifyScriptHash encodeScript (Al.txscripts x)
+      )
+    , ( "datums"
+      , encodeMap stringifyDataHash encodeData (Al.txdats x)
+      )
+    , ( "redeemers"
+      , encodeRedeemers (Al.txrdmrs x)
+      )
+    , ( "bootstrap"
+      , encodeFoldable Shelley.encodeBootstrapWitness (Al.txwitsBoot x)
+      )
+    ]
+
+--
+-- Conversion To Text
+--
+
+stringifyDataHash
+    :: Al.DataHash crypto
+    -> Text
+stringifyDataHash (SafeHash.extractHash -> (CC.UnsafeHash h)) =
+    encodeBase16 (fromShort h)

--- a/server/src/Ogmios/Data/Json/Mary.hs
+++ b/server/src/Ogmios/Data/Json/Mary.hs
@@ -28,9 +28,9 @@ import qualified Ogmios.Data.Json.Allegra as Allegra
 import qualified Ogmios.Data.Json.Shelley as Shelley
 
 import qualified Cardano.Ledger.AuxiliaryData as MA
+import qualified Cardano.Ledger.Core as Sh.Core
 import qualified Cardano.Ledger.Era as Era
 import qualified Cardano.Ledger.Mary.Value as MA
-import qualified Cardano.Ledger.Shelley.Constraints as Sh
 import qualified Cardano.Ledger.ShelleyMA.AuxiliaryData as MA
 import qualified Cardano.Ledger.ShelleyMA.Rules.Utxo as MA
 import qualified Cardano.Ledger.ShelleyMA.TxBody as MA
@@ -93,7 +93,7 @@ encodePParams' =
     Shelley.encodePParams'
 
 encodeProposedPPUpdates
-    :: (Sh.PParamsDelta era ~ Sh.PParamsUpdate era)
+    :: (Sh.Core.PParamsDelta era ~ Sh.PParamsUpdate era)
     => Sh.ProposedPPUpdates era
     -> Json
 encodeProposedPPUpdates =

--- a/server/src/Ogmios/Data/Json/Mary.hs
+++ b/server/src/Ogmios/Data/Json/Mary.hs
@@ -18,8 +18,6 @@ import Ouroboros.Consensus.Cardano.Block
     ( MaryEra )
 import Ouroboros.Consensus.Shelley.Ledger.Block
     ( ShelleyBlock (..) )
-import Shelley.Spec.Ledger.BaseTypes
-    ( StrictMaybe (..) )
 
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as Map
@@ -27,18 +25,20 @@ import qualified Data.Map.Strict as Map
 import qualified Ogmios.Data.Json.Allegra as Allegra
 import qualified Ogmios.Data.Json.Shelley as Shelley
 
-import qualified Cardano.Ledger.AuxiliaryData as MA
-import qualified Cardano.Ledger.Core as Sh.Core
+import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Era as Era
-import qualified Cardano.Ledger.Mary.Value as MA
-import qualified Cardano.Ledger.ShelleyMA.AuxiliaryData as MA
-import qualified Cardano.Ledger.ShelleyMA.Rules.Utxo as MA
-import qualified Cardano.Ledger.ShelleyMA.TxBody as MA
+
 import qualified Shelley.Spec.Ledger.BlockChain as Sh
 import qualified Shelley.Spec.Ledger.PParams as Sh
 import qualified Shelley.Spec.Ledger.STS.Ledger as Sh
 import qualified Shelley.Spec.Ledger.Tx as Sh
 import qualified Shelley.Spec.Ledger.UTxO as Sh
+
+import qualified Cardano.Ledger.AuxiliaryData as MA
+import qualified Cardano.Ledger.Mary.Value as MA
+import qualified Cardano.Ledger.ShelleyMA.AuxiliaryData as MA
+import qualified Cardano.Ledger.ShelleyMA.Rules.Utxo as MA
+import qualified Cardano.Ledger.ShelleyMA.TxBody as MA
 
 --
 -- Encoders
@@ -99,7 +99,7 @@ encodePParams' =
     Shelley.encodePParams'
 
 encodeProposedPPUpdates
-    :: (Sh.Core.PParamsDelta era ~ Sh.PParamsUpdate era)
+    :: (Core.PParamsDelta era ~ Sh.PParamsUpdate era)
     => Sh.ProposedPPUpdates era
     -> Json
 encodeProposedPPUpdates =

--- a/server/src/Ogmios/Data/Json/Mary.hs
+++ b/server/src/Ogmios/Data/Json/Mary.hs
@@ -306,7 +306,7 @@ encodeWitnessSet x = encodeObject
       , encodeFoldable Shelley.encodeWitVKey (Sh.addrWits x)
       )
     , ( "scripts"
-      , encodeMap Shelley.stringifyScriptHash Allegra.encodeTimelock (Sh.scriptWits x)
+      , encodeMap Shelley.stringifyScriptHash Allegra.encodeScript (Sh.scriptWits x)
       )
     , ( "bootstrap"
       , encodeFoldable Shelley.encodeBootstrapWitness (Sh.bootWits x)

--- a/server/src/Ogmios/Data/Json/Mary.hs
+++ b/server/src/Ogmios/Data/Json/Mary.hs
@@ -52,8 +52,8 @@ encodeAuxiliaryData (MA.AuxiliaryData blob scripts) = encodeObject
     [ ( "blob"
       , Shelley.encodeMetadataBlob blob
       )
-    , ( "scriptPreImages"
-      , encodeFoldable Allegra.encodeTimelock scripts
+    , ( "scripts"
+      , encodeFoldable Allegra.encodeScript scripts
       )
     ]
 
@@ -288,10 +288,10 @@ encodeWitnessSet
     => Sh.WitnessSet (MaryEra crypto)
     -> Json
 encodeWitnessSet x = encodeObject
-    [ ( "address"
+    [ ( "signatures"
       , encodeFoldable Shelley.encodeWitVKey (Sh.addrWits x)
       )
-    , ( "script"
+    , ( "scripts"
       , encodeMap Shelley.stringifyScriptHash Allegra.encodeTimelock (Sh.scriptWits x)
       )
     , ( "bootstrap"

--- a/server/src/Ogmios/Data/Json/Mary.hs
+++ b/server/src/Ogmios/Data/Json/Mary.hs
@@ -147,7 +147,7 @@ encodeTxBody (MA.TxBody inps outs certs wdrls fee validity updates _ mint) = enc
       , Shelley.encodeWdrl wdrls
       )
     , ( "fee"
-      , Shelley.encodeCoin fee
+      , encodeCoin fee
       )
     , ( "validityInterval"
       , Allegra.encodeValidityInterval validity
@@ -220,8 +220,8 @@ encodeUtxoFailure = \case
     MA.FeeTooSmallUTxO required actual ->
         encodeObject
             [ ( "feeTooSmall", encodeObject
-                [ ( "requiredFee", Shelley.encodeCoin required )
-                , ( "actualFee", Shelley.encodeCoin actual )
+                [ ( "requiredFee", encodeCoin required )
+                , ( "actualFee", encodeCoin actual )
                 ]
               )
             ]

--- a/server/src/Ogmios/Data/Json/Prelude.hs
+++ b/server/src/Ogmios/Data/Json/Prelude.hs
@@ -23,6 +23,10 @@ module Ogmios.Data.Json.Prelude
     , inefficientEncodingToValue
     , (.:)
 
+      -- * Re-Exports
+    , Coin (..)
+    , StrictMaybe (..)
+
       -- * Basic Types
     , encodeBlockNo
     , encodeBool

--- a/server/src/Ogmios/Data/Json/Prelude.hs
+++ b/server/src/Ogmios/Data/Json/Prelude.hs
@@ -30,6 +30,7 @@ module Ogmios.Data.Json.Prelude
     , encodeByteStringBase16
     , encodeByteStringBase64
     , encodeByteStringBech32
+    , encodeCoin
     , encodeDnsName
     , encodeDouble
     , encodeEpochNo
@@ -76,6 +77,8 @@ import Ogmios.Prelude
 
 import Cardano.Binary
     ( Annotated (..) )
+import Cardano.Ledger.Coin
+    ( Coin (..) )
 import Cardano.Slotting.Block
     ( BlockNo (..) )
 import Cardano.Slotting.Slot
@@ -210,6 +213,11 @@ encodeByteStringBase64 :: ByteString -> Json
 encodeByteStringBase64 =
     encodeText . encodeBase64
 {-# INLINABLE encodeByteStringBase64 #-}
+
+encodeCoin :: Coin -> Json
+encodeCoin =
+    encodeInteger . unCoin
+{-# INLINEABLE encodeCoin #-}
 
 encodeDnsName :: DnsName -> Json
 encodeDnsName =

--- a/server/src/Ogmios/Data/Json/Query.hs
+++ b/server/src/Ogmios/Data/Json/Query.hs
@@ -591,7 +591,7 @@ parseGetGenesisConfig genResultInEra = do
                     BlockQuery $ QueryIfCurrentShelley GetGenesisConfig
                 , encodeResult =
                     let encodeGenesis =
-                            Shelley.encodeShelleyGenesis . getCompactGenesis
+                            Shelley.encodeGenesis . getCompactGenesis
                     in either encodeMismatchEraInfo encodeGenesis
                 , genResult =
                     genResultInEra (Proxy @(ShelleyEra crypto))
@@ -602,7 +602,7 @@ parseGetGenesisConfig genResultInEra = do
                     BlockQuery $ QueryIfCurrentAllegra GetGenesisConfig
                 , encodeResult =
                     let encodeGenesis =
-                            Shelley.encodeShelleyGenesis . getCompactGenesis
+                            Shelley.encodeGenesis . getCompactGenesis
                     in either encodeMismatchEraInfo encodeGenesis
                 , genResult =
                     genResultInEra (Proxy @(AllegraEra crypto))
@@ -613,7 +613,7 @@ parseGetGenesisConfig genResultInEra = do
                     BlockQuery $ QueryIfCurrentMary GetGenesisConfig
                 , encodeResult =
                     let encodeGenesis =
-                            Shelley.encodeShelleyGenesis . getCompactGenesis
+                            Shelley.encodeGenesis . getCompactGenesis
                     in either encodeMismatchEraInfo encodeGenesis
                 , genResult =
                     genResultInEra (Proxy @(MaryEra crypto))
@@ -624,7 +624,7 @@ parseGetGenesisConfig genResultInEra = do
                     BlockQuery $ QueryIfCurrentAlonzo GetGenesisConfig
                 , encodeResult =
                     let encodeGenesis =
-                            Shelley.encodeShelleyGenesis . getCompactGenesis
+                            Shelley.encodeGenesis . getCompactGenesis
                      in either encodeMismatchEraInfo encodeGenesis
                 , genResult =
                     genResultInEra (Proxy @(AlonzoEra crypto))

--- a/server/src/Ogmios/Data/Json/Shelley.hs
+++ b/server/src/Ogmios/Data/Json/Shelley.hs
@@ -763,7 +763,7 @@ encodePrevHash = \case
     Sh.BlockHash h -> encodeHashHeader h
 
 encodeProposedPPUpdates
-    :: forall era. (Sh.PParamsDelta era ~ Sh.PParams' StrictMaybe era)
+    :: forall era. (Sh.Core.PParamsDelta era ~ Sh.PParams' StrictMaybe era)
     => Sh.ProposedPPUpdates era
     -> Json
 encodeProposedPPUpdates (Sh.ProposedPPUpdates m) =
@@ -951,7 +951,7 @@ encodeTxOut (Sh.TxOut addr coin) = encodeObject
     ]
 
 encodeUpdate
-    :: forall era. (Sh.PParamsDelta era ~ Sh.PParams' StrictMaybe era)
+    :: forall era. (Sh.Core.PParamsDelta era ~ Sh.PParams' StrictMaybe era)
     => Sh.Update era
     -> Json
 encodeUpdate (Sh.Update update epoch) = encodeObject

--- a/server/src/Ogmios/Data/Json/Shelley.hs
+++ b/server/src/Ogmios/Data/Json/Shelley.hs
@@ -158,10 +158,10 @@ encodeBootstrapWitness (Sh.BootstrapWitness key sig cc attr) = encodeObject
       )
     ]
 
-encodeCompactGenesis
+encodeShelleyGenesis
     :: Sh.ShelleyGenesis era
     -> Json
-encodeCompactGenesis x = encodeObject
+encodeShelleyGenesis x = encodeObject
     [ ( "systemStart"
       , encodeUtcTime (Sh.sgSystemStart x)
       )
@@ -226,12 +226,6 @@ encodeChainCode
 encodeChainCode cc
     | BS.null (Sh.unChainCode cc) = encodeNull
     | otherwise = encodeByteStringBase16 (Sh.unChainCode cc)
-
-encodeCoin
-    :: Sh.Coin
-    -> Json
-encodeCoin =
-    encodeInteger . Sh.unCoin
 
 encodeCredential
     :: forall any era. (any :\: 'Sh.StakePool)

--- a/server/src/Ogmios/Data/Json/Shelley.hs
+++ b/server/src/Ogmios/Data/Json/Shelley.hs
@@ -892,8 +892,15 @@ encodeTx mode x = encodeObjectWithMode mode
     , ( "body"
       , encodeTxBody (Sh.body x)
       )
-      -- FIXME: We should really return metadata: null when there's no metadata.
+      -- NOTE:
+      -- We should really return metadata: null when there's no metadata.
       -- Right now, this returns { hash: null, body: null } when null.
+      --
+      -- The reason for writing it in such a way is slightly _silly_ and because
+      -- of the way the generators are currently constructed. Indeed, since the
+      -- metadata hash and body are strictly decoupled in the transaction model,
+      -- they end up being generated separately and as a result, the generator
+      -- may generate actually invalid cases like this.
     , ( "metadata", encodeObject
         [ ( "hash"
           , encodeStrictMaybe encodeAuxiliaryDataHash (Sh._mdHash (Sh.body x))

--- a/server/src/Ogmios/Data/Json/Shelley.hs
+++ b/server/src/Ogmios/Data/Json/Shelley.hs
@@ -1191,10 +1191,10 @@ encodeWitnessSet
     => Sh.WitnessSet (ShelleyEra crypto)
     -> Json
 encodeWitnessSet x = encodeObject
-    [ ( "address"
+    [ ( "signatures"
       , encodeFoldable encodeWitVKey (Sh.addrWits x)
       )
-    , ( "script"
+    , ( "scripts"
       , encodeMap stringifyScriptHash encodeMultiSig (Sh.scriptWits x)
       )
     , ( "bootstrap"
@@ -1212,14 +1212,8 @@ encodeWitVKey
     :: Crypto crypto
     => Sh.WitVKey Sh.Witness crypto
     -> Json
-encodeWitVKey (Sh.WitVKey key sig) = encodeObject
-    [ ( "key"
-      , encodeVKey key
-      )
-    , ( "signature"
-      , encodeSignedDSIGN sig
-      )
-    ]
+encodeWitVKey (Sh.WitVKey key sig) =
+    encodeObject [(stringifyVKey  key, encodeSignedDSIGN sig)]
 
 --
 -- Conversion To Text
@@ -1271,6 +1265,13 @@ stringifyScriptHash
     -> Text
 stringifyScriptHash (Sh.ScriptHash (CC.UnsafeHash h)) =
     encodeBase16 (fromShort h)
+
+stringifyVKey
+    :: Crypto crypto
+    => Sh.VKey any crypto
+    -> Text
+stringifyVKey =
+    encodeBase16 . CC.rawSerialiseVerKeyDSIGN . Sh.unVKey
 
 --
 -- Helpers

--- a/server/test/unit/Ogmios/Data/JsonSpec.hs
+++ b/server/test/unit/Ogmios/Data/JsonSpec.hs
@@ -115,7 +115,7 @@ import Ouroboros.Network.Protocol.LocalTxSubmission.Type
 import Shelley.Spec.Ledger.Delegation.Certificates
     ( PoolDistr )
 import Shelley.Spec.Ledger.PParams
-    ( PParams, ProposedPPUpdates )
+    ( ProposedPPUpdates )
 import Shelley.Spec.Ledger.UTxO
     ( UTxO )
 import Test.Hspec
@@ -154,6 +154,7 @@ import Type.Reflection
 import Test.Consensus.Cardano.Generators
     ()
 
+import qualified Cardano.Ledger.Core as Core
 import qualified Codec.Json.Wsp.Handler as Wsp
 import qualified Data.Aeson as Json
 import qualified Data.Aeson.Types as Json
@@ -631,8 +632,8 @@ genDelegationAndRewardsResult _ = frequency
 genPParamsResult
     :: forall crypto era. (crypto ~ StandardCrypto, Typeable era)
     => Proxy era
-    -> Proxy (QueryResult crypto (PParams era))
-    -> Gen (QueryResult crypto (PParams era))
+    -> Proxy (QueryResult crypto (Core.PParams era))
+    -> Gen (QueryResult crypto (Core.PParams era))
 genPParamsResult _ _ =
     fromMaybe (error "genPParamsResult: unsupported era")
         (genShelley <|> genAllegra <|> genMary)


### PR DESCRIPTION
It was surprisingly easier than I thought (I was imagining much more rippling effects due to Alonzo in the consensus code and state query protocol). 

- :round_pushpin: **re-generate .cabal files using hpack-0.34.4**
  
- :round_pushpin: **Upgrade dependencies to latest cardano-node master including early Alonzo support.**
    So far, it _compiles_ (which is already quite something in itself!).
  Yet, I've left a few holes in places where conversion from Alonzo
  data-types to JSON should happen. Eventually, the JSON specification
  will also have to cover the new Alonzo types, and then, the TypeScript
  client.

- :round_pushpin: **Begin Alonzo -> Json encoders, starting with the bigger piece: 'encodeAlonzoBlock'**
    I ended up changing a bit some of the _previous_ schemas as well, in
  Shelley, Allegra and Mary to make the model somewhat more consistent.

  I've documented the breaking changes in the CHANGELOG already and they
  are pretty straightforward to fix (mainly some renaming).

  So far, not major blocker and now remains the 'encodeTxBody' which
  include a few new things in the Alonzo era.

- :round_pushpin: **Continue Alonzo -> Json encoders, for 'encodeTxBody' & 'encodeRedeemers'.**
    We now have Alonzo blocks!

- :round_pushpin: **Continue Alonzo -> Json encoders, for 'encodeAlonzoGenesis' & 'encodeUtxo'**
    Also wired that into Ogmios.Data.Json.Query. Weirdly enough, the 'getGenesisConfig' query is actually not era-dependent and can always return the _ShelleyGenesis_. This is maybe unintended so I've asked the consensus team to confirm.

- :round_pushpin: **Implement Json encoders for Alonzo's ledger failures. Oof!**
  
- :round_pushpin: **Clean-up / make more uniform module imports in the various Json modules.**

- :round_pushpin: **Update JSON-WSP specifications for breaking changes coming with Alonzo fork**
    Note that, the format for Alonzo block is still not covered by the specification. This will come in a bit. I'd like to introduce these changes in two steps.

- :round_pushpin: **Temporarily update Dockerfile to pre-build against latest compiling Ogmios.**

---

TODO:

- [x] Update the JSON-WSP specification to cover breaking changes.
- [ ] Update the JSON-WSP specification for the Alonzo stuff
- [ ] Update TypeScript client for Alonzo.
- [ ] Enable Alonzo types in the QuickCheck JSON property testing.
- [ ] Update Dockerfile to point to a newer cardano-node.

