### PR TITLE
Alonzo - Part 2 (JSON Schema for Alonzo data-types) 

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -42,8 +42,8 @@ jobs:
     - name: 🔨 Build & Test
       run: |
         cd server
-        stack --no-terminal build                 --haddock --no-haddock-deps --flag ogmios:production
-        stack --no-terminal test ogmios:unit      --haddock --no-haddock-deps --flag ogmios:production
+        stack --no-terminal test --flag ogmios:production --no-run-tests
+        stack --no-terminal test --flag ogmios:production                 ogmios:unit
 
   docker:
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,6 @@ pre: "<b>5. </b>"
 - The `moveInstantaneousRewards` certificates have a new optional field `value` and not only a `rewards` map as before. 
   When `value` is present, it signifies that rewards are moved to the other pot. 
 
-- The 'networkMismatch` error can now also be related to a mismatch from the network and the reward account coming from a 
-  pool registration certificate. 
-
 #### Removed
 
 ø

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,21 +36,37 @@ pre: "<b>5. </b>"
 
 #### Changed
 
-- :warning: **Breaking-Change** :warning: Auxiliary data's `scriptPreImages` in Allegra & Mary has been replaced with a field `scripts` which has one field `native`. The value of `native` corresponds to what used to be the value of `scriptPreImages`. In Alonzo, `scripts` may also have another field `plutus` with a serialized Plutus script. 
-
-- :warning: **Breaking-Change** :warning: Transactions witnesses' `address` has been renamed into `signatures`, and the structure of the object has been changed to be a map from public keys to signatures (instead of an object with two field `key` & `signature`). 
-
-- :warning: **Breaking-Change** :warning: Transactions witnesses' `script` has been renamed into `scripts`.
-
-- :warning: **Breaking-Change** :warning: Transaction submission errors' `networkMismatch` now returns an `invalidEntities` list of object in the form of `{ "type": ..., "entity": }` where `type` is a text tag designating the type of entity for which there is a network identifier mismatch. Values can be `address`, `rewardAccount` and since Alonzo `transactionBody`. The `entity` field contains some details specific to the type of entity. Before, it used to be two distinct fields `invalidAddresses` and `invalidRewardAccounts`. 
-
-- :warning: **Breaking-Change** :warning: Empty transaction metadata are no longer materialized by an object with two null fields (`{ "hash": null, "body": null }`). Empty transaction metadata are now equal to `null`. 
-
-- :warning: **Breaking-Change** :warning: `map` metadatum in transactions' metadata are no longer materialized as a list of list of singleton objects: `[[{ "k": ... }, { "v": ... }], ...]` but instead, as a list of object with two fields `k` and `v`: `[{ "k": ..., "v": ...}, ...]`. This was an oversight from the encoder which was never intended to end up that way but happened to slip in because the schema for metadatum was not specified / documented (and therefore, also escaped testing). This is now documented properly.
-
-- :warning: **Breaking-Change** :warning: The `TxOut` (and thus Utxo) model definitions have been unified and harmonized across all eras. That is, pre-Mary eras now also wrap Ada values in an object with a field `"coins": ...`. This reduces the discrepancy between eras for there's now a single TxOut representation valid across all eras. Some fields are however optional and only present in some eras (e.g. `datum` starting from Alonzo)
-
 - The `moveInstantaneousRewards` certificates have a new optional field `value` and not only a `rewards` map as before. When `value` is present, it signifies that rewards are moved to the other pot. 
+- :warning: **Server Breaking Changes** :warning: 
+
+  - Auxiliary data's `scriptPreImages` in Allegra & Mary has been replaced with a field `scripts` which has one field `native`. The value of `native` corresponds to what used to be the value of `scriptPreImages`. In Alonzo, `scripts` may also have another field `plutus` with a serialized Plutus script. 
+
+  - Transactions witnesses' `address` has been renamed into `signatures`, and the structure of the object has been changed to be a map from public keys to signatures (instead of an object with two field `key` & `signature`). 
+
+  - Transactions witnesses' `script` has been renamed into `scripts`.
+
+  - Transaction submission errors' `networkMismatch` now returns an `invalidEntities` list of object in the form of `{ "type": ..., "entity": }` where `type` is a text tag designating the type of entity for which there is a network identifier mismatch. Values can be `address`, `rewardAccount` and since Alonzo `transactionBody`. The `entity` field contains some details specific to the type of entity. Before, it used to be two distinct fields `invalidAddresses` and `invalidRewardAccounts`. 
+
+  - Empty transaction metadata are no longer materialized by an object with two null fields (`{ "hash": null, "body": null }`). Empty transaction metadata are now equal to `null`. 
+
+  - `map` metadatum in transactions' metadata are no longer materialized as a list of list of singleton objects: `[[{ "k": ... }, { "v": ... }], ...]` but instead, as a list of object with two fields `k` and `v`: `[{ "k": ..., "v": ...}, ...]`. This was an oversight from the encoder which was never intended to end up that way but happened to slip in because the schema for metadatum was not specified / documented (and therefore, also escaped testing). This is now documented properly.
+
+  - The `TxOut` (and thus Utxo) model definitions have been unified and harmonized across all eras. That is, pre-Mary eras now also wrap Ada values in an object with a field `"coins": ...`. This reduces the discrepancy between eras for there's now a single TxOut representation valid across all eras. Some fields are however optional and only present in some eras (e.g. `datum` starting from Alonzo)
+
+- :warning: **Client/TypeScript Breaking Changes** :warning: 
+
+  - Type `DelegationsAndRewards` renamed into `DelegationsAndRewardsByAccounts`
+  - Type `DelegationsAndRewards1` renamed into `DelegationsAndRewards`
+  - Type `NonMyopicMemberRewards1` renamed into `NonMyopicMemberRewards`
+  - Type `TxTooLarge1` renamed into `TxTooLarge`
+  - Type `FeeTooSmall1` renamed into `FeeTooSmall`
+  - Type `NetworkMismatch1` renamed into `NetworkMismatch`
+  - Type `Proposal` renamed into `UpdateProposalShelley`
+  - Types `Utxo1`, `Utxo2`, `UtxoMary` have been unified into a single `Utxo` type. Refer to server breaking changes for details.
+  - Many types `NullX` merged into a single `Null` type
+  - Query types have been renamed from `ledgerTip1` to `GetLedgerTip` and so forth for all queries.
+
+
 #### Removed
 
 ø

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ pre: "<b>5. </b>"
 
 - Integrated with the Cardano eco-system corresponding to cardano-node@1.27.0. Bumped the docker-compose installation accordingly.
 
-- Three new possible errors from the transaction submission coming with cardano-node@1.27.0:
+- New possible errors from the transaction submission coming with cardano-node@1.27.0:
 
   - `mirTransferNotCurrentlyAllowed`
   - `mirNegativeTransferNotCurrentlyAllowed`
@@ -19,6 +19,20 @@ pre: "<b>5. </b>"
 
   These errors are related to transactions issuing MIR certificates which can only be done by 
   genesis delegates. So this change should not impact any 'standard' user. 
+
+- New possible errors from the transaction submission coming with the Alonzo era:
+  - `unredeemableScripts`
+  - `datumsMismatch`
+  - `extraDataMismatch`
+  - `missingRequiredSignatures`
+  - `collateralTooSmall`
+  - `collateralIsScript`
+  - `collateralHasNonAdaAssets`
+  - `tooManyCollateralInputs`
+  - `executionUnitsTooLarge`
+  - `outsideForecast`
+  - `validationTagMismatch`
+  - `collectErrors`
 
 #### Changed
 
@@ -34,9 +48,9 @@ pre: "<b>5. </b>"
 
 - :warning: **Breaking-Change** :warning: `map` metadatum in transactions' metadata are no longer materialized as a list of list of singleton objects: `[[{ "k": ... }, { "v": ... }], ...]` but instead, as a list of object with two fields `k` and `v`: `[{ "k": ..., "v": ...}, ...]`. This was an oversight from the encoder which was never intended to end up that way but happened to slip in because the schema for metadatum was not specified / documented (and therefore, also escaped testing). This is now documented properly.
 
-- The `moveInstantaneousRewards` certificates have a new optional field `value` and not only a `rewards` map as before. 
-  When `value` is present, it signifies that rewards are moved to the other pot. 
+- :warning: **Breaking-Change** :warning: The `TxOut` (and thus Utxo) model definitions have been unified and harmonized across all eras. That is, pre-Mary eras now also wrap Ada values in an object with a field `"coins": ...`. This reduces the discrepancy between eras for there's now a single TxOut representation valid across all eras. Some fields are however optional and only present in some eras (e.g. `datum` starting from Alonzo)
 
+- The `moveInstantaneousRewards` certificates have a new optional field `value` and not only a `rewards` map as before. When `value` is present, it signifies that rewards are moved to the other pot. 
 #### Removed
 
 ø

--- a/clients/TypeScript/packages/client/src/StateQuery/StateQueryClient.ts
+++ b/clients/TypeScript/packages/client/src/StateQuery/StateQueryClient.ts
@@ -19,7 +19,8 @@ import {
 } from '../errors'
 import {
   currentEpoch,
-  currentProtocolParameters, delegationsAndRewards,
+  currentProtocolParameters,
+  delegationsAndRewards,
   eraStart,
   genesisConfig,
   ledgerTip,

--- a/clients/TypeScript/packages/client/src/StateQuery/queries/delegationsAndRewards.ts
+++ b/clients/TypeScript/packages/client/src/StateQuery/queries/delegationsAndRewards.ts
@@ -1,6 +1,8 @@
 import {
-  DelegationsAndRewards1,
-  EraMismatch, Hash16,
+  DelegationsAndRewardsByAccounts,
+  DelegationsAndRewards,
+  EraMismatch,
+  Hash16,
   Ogmios
 } from '@cardano-ogmios/schema'
 import { EraMismatchError, QueryUnavailableInCurrentEraError, UnknownResultError } from '../../errors'
@@ -10,16 +12,16 @@ import { Query } from '../Query'
 const isEraMismatch = (result: Ogmios['QueryResponse[delegationsAndRewards]']['result']): result is EraMismatch =>
   (result as EraMismatch).eraMismatch !== undefined
 
-const isDelegationsAndRewards = (result: Ogmios['QueryResponse[delegationsAndRewards]']['result']): result is DelegationsAndRewards1 => {
-  const sample = Object.entries(result as DelegationsAndRewards1)[0]
+const isDelegationsAndRewardsByAccounts = (result: Ogmios['QueryResponse[delegationsAndRewards]']['result']): result is DelegationsAndRewardsByAccounts => {
+  const sample = Object.entries(result as DelegationsAndRewards)[0]
   return typeof sample[0] === 'string' && (sample[1].delegate !== undefined || sample[1].rewards !== undefined)
 }
 
-export const delegationsAndRewards = (stakeKeyHashes: Hash16[], context?: InteractionContext): Promise<DelegationsAndRewards1> =>
+export const delegationsAndRewards = (stakeKeyHashes: Hash16[], context?: InteractionContext): Promise<DelegationsAndRewardsByAccounts> =>
   Query<
     Ogmios['Query'],
     Ogmios['QueryResponse[delegationsAndRewards]'],
-    DelegationsAndRewards1
+    DelegationsAndRewardsByAccounts
   >({
     methodName: 'Query',
     args: {
@@ -33,7 +35,7 @@ export const delegationsAndRewards = (stakeKeyHashes: Hash16[], context?: Intera
         const { eraMismatch } = response.result
         const { ledgerEra, queryEra } = eraMismatch
         return reject(new EraMismatchError(queryEra, ledgerEra))
-      } else if (isDelegationsAndRewards(response.result)) {
+      } else if (isDelegationsAndRewardsByAccounts(response.result)) {
         return resolve(response.result)
       } else {
         return reject(new UnknownResultError(response.result))

--- a/clients/TypeScript/packages/client/src/StateQuery/queries/nonMyopicMemberRewards.ts
+++ b/clients/TypeScript/packages/client/src/StateQuery/queries/nonMyopicMemberRewards.ts
@@ -2,7 +2,7 @@ import {
   EraMismatch,
   Hash16,
   Lovelace,
-  NonMyopicMemberRewards1,
+  NonMyopicMemberRewards,
   Ogmios
 } from '@cardano-ogmios/schema'
 import { EraMismatchError, QueryUnavailableInCurrentEraError, UnknownResultError } from '../../errors'
@@ -12,16 +12,16 @@ import { Query } from '../Query'
 const isEraMismatch = (result: Ogmios['QueryResponse[nonMyopicMemberRewards]']['result']): result is EraMismatch =>
   (result as EraMismatch).eraMismatch !== undefined
 
-const isNonMyopicMemberRewards = (result: Ogmios['QueryResponse[nonMyopicMemberRewards]']['result']): result is NonMyopicMemberRewards1 =>
+const isNonMyopicMemberRewards = (result: Ogmios['QueryResponse[nonMyopicMemberRewards]']['result']): result is NonMyopicMemberRewards =>
   typeof Object.values(
-    Object.values(result as NonMyopicMemberRewards1)[0]
+    Object.values(result as NonMyopicMemberRewards)[0]
   )[0] === 'number'
 
-export const nonMyopicMemberRewards = (input: (Lovelace | Hash16)[], context?: InteractionContext): Promise<NonMyopicMemberRewards1> =>
+export const nonMyopicMemberRewards = (input: (Lovelace | Hash16)[], context?: InteractionContext): Promise<NonMyopicMemberRewards> =>
   Query<
     Ogmios['Query'],
     Ogmios['QueryResponse[nonMyopicMemberRewards]'],
-    NonMyopicMemberRewards1
+    NonMyopicMemberRewards
   >({
     methodName: 'Query',
     args: {

--- a/clients/TypeScript/packages/client/src/StateQuery/queries/utxo.ts
+++ b/clients/TypeScript/packages/client/src/StateQuery/queries/utxo.ts
@@ -2,9 +2,9 @@ import {
   Address,
   EraMismatch,
   Ogmios,
-  Utxo1,
-  Utxo2,
-  UtxoMary
+  TxIn,
+  TxOut,
+  Utxo
 } from '@cardano-ogmios/schema'
 import { EraMismatchError, QueryUnavailableInCurrentEraError, UnknownResultError } from '../../errors'
 import { InteractionContext } from '../../Connection'
@@ -13,24 +13,21 @@ import { Query } from '../Query'
 const isEraMismatch = (result: Ogmios['QueryResponse[utxo]']['result']): result is EraMismatch =>
   (result as EraMismatch).eraMismatch !== undefined
 
-const isArrayOfUtxo = (result: Ogmios['QueryResponse[utxo]']['result']): result is Utxo1 => {
+const isArrayOfUtxo = (result: Ogmios['QueryResponse[utxo]']['result']): result is Utxo => {
   if (!Array.isArray(result)) {
     return false
   } else if (Array.isArray(result) && result.length === 0) {
     return true
   }
-  const item = result[0] as (Utxo2 | UtxoMary)
-  return (Array.isArray(item) && item.length === 0) ||
-    'index' in item[0] ||
-    ('index' in item[0] &&
-      (typeof item[1].value === 'number' || typeof item[1].value.coins === 'number'))
+  const item = result[0] as [TxIn, TxOut]
+  return 'index' in item[0] || typeof item[1].value.coins === 'number'
 }
 
-export const utxo = (addresses: Address[], context?: InteractionContext): Promise<Utxo1> =>
+export const utxo = (addresses: Address[], context?: InteractionContext): Promise<Utxo> =>
   Query<
     Ogmios['Query'],
     Ogmios['QueryResponse[utxo]'],
-    Utxo1
+    Utxo
   >({
     methodName: 'Query',
     args: {

--- a/clients/TypeScript/packages/client/src/TxSubmission/errors.ts
+++ b/clients/TypeScript/packages/client/src/TxSubmission/errors.ts
@@ -3,10 +3,17 @@ import {
   AddressAttributesTooLarge,
   AlreadyDelegating,
   BadInputs,
+  CollateralHasNonAdaAssets,
+  CollateralIsScript,
+  CollateralTooSmall,
+  CollectErrors,
+  DatumsMismatch,
   DelegateNotRegistered,
   DuplicateGenesisVrf,
+  ExecutionUnitsTooLarge,
   ExpiredUtxo,
-  FeeTooSmall1,
+  ExtraDataMismatch,
+  FeeTooSmall,
   InsufficientFundsForMir,
   InsufficientGenesisSignatures,
   InvalidMetadata,
@@ -15,13 +22,15 @@ import {
   MirProducesNegativeUpdate,
   MirTransferNotCurrentlyAllowed,
   MissingAtLeastOneInputUtxo,
+  MissingRequiredSignatures,
   MissingScriptWitnesses,
   MissingTxMetadata,
   MissingTxMetadataHash,
   MissingVkWitnesses,
-  NetworkMismatch1,
+  NetworkMismatch,
   NonGenesisVoters,
   OutputTooSmall,
+  OutsideForecast,
   OutsideOfValidityInterval,
   PoolCostTooSmall,
   ProtocolVersionCannotFollow,
@@ -34,14 +43,17 @@ import {
   SubmitFail,
   TooLateForMir,
   TooManyAssetsInOutput,
+  TooManyCollateralInputs,
   TriesToForgeAda,
   TxMetadataHashMismatch,
-  TxTooLarge1,
+  TxTooLarge,
   TxValidationError,
   UnknownGenesisKey,
   UnknownOrIncompleteWithdrawals,
+  UnredeemableScripts,
   UpdateWrongEpoch,
   UtxoValidationError,
+  ValidationTagMismatch,
   ValueNotConserved,
   WrongCertificateType,
   WrongPoolCertificate,
@@ -59,12 +71,12 @@ type SubmitTxErrorShelley =
   | TxMetadataHashMismatch
   | BadInputs
   | ExpiredUtxo
-  | TxTooLarge1
+  | TxTooLarge
   | MissingAtLeastOneInputUtxo
   | InvalidMetadata
-  | FeeTooSmall1
+  | FeeTooSmall
   | ValueNotConserved
-  | NetworkMismatch1
+  | NetworkMismatch
   | OutputTooSmall
   | AddressAttributesTooLarge
   | DelegateNotRegistered
@@ -92,6 +104,18 @@ type SubmitTxErrorShelley =
   | OutsideOfValidityInterval
   | TriesToForgeAda
   | TooManyAssetsInOutput
+  | UnredeemableScripts
+  | DatumsMismatch
+  | ExtraDataMismatch
+  | MissingRequiredSignatures
+  | CollateralTooSmall
+  | CollateralIsScript
+  | CollateralHasNonAdaAssets
+  | TooManyCollateralInputs
+  | ExecutionUnitsTooLarge
+  | OutsideForecast
+  | ValidationTagMismatch
+  | CollectErrors
 
 export const errors = {
   byron: {
@@ -218,10 +242,10 @@ export const errors = {
       }
     },
     TxTooLarge: {
-      assert: (item: SubmitTxErrorShelley): item is TxTooLarge1 =>
-        (item as TxTooLarge1).txTooLarge !== undefined,
+      assert: (item: SubmitTxErrorShelley): item is TxTooLarge =>
+        (item as TxTooLarge).txTooLarge !== undefined,
       Error: class TxTooLargeError extends CustomError {
-        public constructor (rawError: TxTooLarge1) {
+        public constructor (rawError: TxTooLarge) {
           super()
           this.message = JSON.stringify(rawError.txTooLarge, null, 2)
         }
@@ -248,10 +272,10 @@ export const errors = {
       }
     },
     FeeTooSmall: {
-      assert: (item: SubmitTxErrorShelley): item is FeeTooSmall1 =>
-        (item as FeeTooSmall1).feeTooSmall !== undefined,
+      assert: (item: SubmitTxErrorShelley): item is FeeTooSmall =>
+        (item as FeeTooSmall).feeTooSmall !== undefined,
       Error: class FeeTooSmallError extends CustomError {
-        public constructor (rawError: FeeTooSmall1) {
+        public constructor (rawError: FeeTooSmall) {
           super()
           this.message = JSON.stringify(rawError.feeTooSmall, null, 2)
         }
@@ -268,10 +292,10 @@ export const errors = {
       }
     },
     NetworkMismatch: {
-      assert: (item: SubmitTxErrorShelley): item is NetworkMismatch1 =>
-        (item as NetworkMismatch1).networkMismatch !== undefined,
+      assert: (item: SubmitTxErrorShelley): item is NetworkMismatch =>
+        (item as NetworkMismatch).networkMismatch !== undefined,
       Error: class NetworkMismatchError extends CustomError {
-        public constructor (rawError: NetworkMismatch1) {
+        public constructor (rawError: NetworkMismatch) {
           super()
           this.message = JSON.stringify(rawError.networkMismatch, null, 2)
         }
@@ -544,6 +568,126 @@ export const errors = {
         public constructor (rawError: TooManyAssetsInOutput) {
           super()
           this.message = JSON.stringify(rawError.tooManyAssetsInOutput, null, 2)
+        }
+      }
+    },
+    UnredeemableScripts: {
+      assert: (item: SubmitTxErrorShelley): item is UnredeemableScripts =>
+        (item as UnredeemableScripts).unredeemableScripts !== undefined,
+      Error: class UnredeemableScriptsError extends CustomError {
+        public constructor (rawError: UnredeemableScripts) {
+          super()
+          this.message = JSON.stringify(rawError.unredeemableScripts, null, 2)
+        }
+      }
+    },
+    DatumsMismatch: {
+      assert: (item: SubmitTxErrorShelley): item is DatumsMismatch =>
+        (item as DatumsMismatch).datumsMismatch !== undefined,
+      Error: class DatumsMismatchError extends CustomError {
+        public constructor (rawError: DatumsMismatch) {
+          super()
+          this.message = JSON.stringify(rawError.datumsMismatch, null, 2)
+        }
+      }
+    },
+    ExtraDataMismatch: {
+      assert: (item: SubmitTxErrorShelley): item is ExtraDataMismatch =>
+        (item as ExtraDataMismatch).extraDataMismatch !== undefined,
+      Error: class ExtraDataMismatchError extends CustomError {
+        public constructor (rawError: ExtraDataMismatch) {
+          super()
+          this.message = JSON.stringify(rawError.extraDataMismatch, null, 2)
+        }
+      }
+    },
+    MissingRequiredSignatures: {
+      assert: (item: SubmitTxErrorShelley): item is MissingRequiredSignatures =>
+        (item as MissingRequiredSignatures).missingRequiredSignatures !== undefined,
+      Error: class MissingRequiredSignaturesError extends CustomError {
+        public constructor (rawError: MissingRequiredSignatures) {
+          super()
+          this.message = JSON.stringify(rawError.missingRequiredSignatures, null, 2)
+        }
+      }
+    },
+    CollateralTooSmall: {
+      assert: (item: SubmitTxErrorShelley): item is CollateralTooSmall =>
+        (item as CollateralTooSmall).collateralTooSmall !== undefined,
+      Error: class CollateralTooSmallError extends CustomError {
+        public constructor (rawError: CollateralTooSmall) {
+          super()
+          this.message = JSON.stringify(rawError.collateralTooSmall, null, 2)
+        }
+      }
+    },
+    CollateralIsScript: {
+      assert: (item: SubmitTxErrorShelley): item is CollateralIsScript =>
+        (item as CollateralIsScript).collateralIsScript !== undefined,
+      Error: class CollateralIsScriptError extends CustomError {
+        public constructor (rawError: CollateralIsScript) {
+          super()
+          this.message = JSON.stringify(rawError.collateralIsScript, null, 2)
+        }
+      }
+    },
+    CollateralHasNonAdaAssets: {
+      assert: (item: SubmitTxErrorShelley): item is CollateralHasNonAdaAssets =>
+        (item as CollateralHasNonAdaAssets).collateralHasNonAdaAssets !== undefined,
+      Error: class CollateralHasNonAdaAssetsError extends CustomError {
+        public constructor (rawError: CollateralHasNonAdaAssets) {
+          super()
+          this.message = JSON.stringify(rawError.collateralHasNonAdaAssets, null, 2)
+        }
+      }
+    },
+    TooManyCollateralInputs: {
+      assert: (item: SubmitTxErrorShelley): item is TooManyCollateralInputs =>
+        (item as TooManyCollateralInputs).tooManyCollateralInputs !== undefined,
+      Error: class TooManyCollateralInputsError extends CustomError {
+        public constructor (rawError: TooManyCollateralInputs) {
+          super()
+          this.message = JSON.stringify(rawError.tooManyCollateralInputs, null, 2)
+        }
+      }
+    },
+    ExecutionUnitsTooLarge: {
+      assert: (item: SubmitTxErrorShelley): item is ExecutionUnitsTooLarge =>
+        (item as ExecutionUnitsTooLarge).executionUnitsTooLarge !== undefined,
+      Error: class ExecutionUnitsTooLargeError extends CustomError {
+        public constructor (rawError: ExecutionUnitsTooLarge) {
+          super()
+          this.message = JSON.stringify(rawError.executionUnitsTooLarge, null, 2)
+        }
+      }
+    },
+    OutsideForecast: {
+      assert: (item: SubmitTxErrorShelley): item is OutsideForecast =>
+        (item as OutsideForecast).outsideForecast !== undefined,
+      Error: class OutsideForecastError extends CustomError {
+        public constructor (rawError: OutsideForecast) {
+          super()
+          this.message = JSON.stringify(rawError.outsideForecast, null, 2)
+        }
+      }
+    },
+    ValidationTagMismatch: {
+      assert: (item: SubmitTxErrorShelley): item is ValidationTagMismatch =>
+        (item as ValidationTagMismatch) === 'validationTagMismatch',
+      Error: class ValidationTagMismatchError extends CustomError {
+        public constructor (rawError: ValidationTagMismatch) {
+          super()
+          this.message = JSON.stringify(rawError, null, 2)
+        }
+      }
+    },
+    CollectErrors: {
+      assert: (item: SubmitTxErrorShelley): item is CollectErrors =>
+        (item as CollectErrors).collectErrors !== undefined,
+      Error: class CollectErrorsError extends CustomError {
+        public constructor (rawError: CollectErrors) {
+          super()
+          this.message = JSON.stringify(rawError.collectErrors, null, 2)
         }
       }
     }

--- a/clients/TypeScript/packages/client/src/TxSubmission/submitTx.ts
+++ b/clients/TypeScript/packages/client/src/TxSubmission/submitTx.ts
@@ -118,6 +118,30 @@ export const submitTx = (bytes: string, context?: InteractionContext) =>
                 return new errors.shelley.TriesToForgeAda.Error(failure)
               } else if (errors.shelley.TooManyAssetsInOutput.assert(failure)) {
                 return new errors.shelley.TooManyAssetsInOutput.Error(failure)
+              } else if (errors.shelley.UnredeemableScripts.assert(failure)) {
+                return new errors.shelley.UnredeemableScripts.Error(failure)
+              } else if (errors.shelley.DatumsMismatch.assert(failure)) {
+                return new errors.shelley.DatumsMismatch.Error(failure)
+              } else if (errors.shelley.ExtraDataMismatch.assert(failure)) {
+                return new errors.shelley.ExtraDataMismatch.Error(failure)
+              } else if (errors.shelley.MissingRequiredSignatures.assert(failure)) {
+                return new errors.shelley.MissingRequiredSignatures.Error(failure)
+              } else if (errors.shelley.CollateralTooSmall.assert(failure)) {
+                return new errors.shelley.CollateralTooSmall.Error(failure)
+              } else if (errors.shelley.CollateralIsScript.assert(failure)) {
+                return new errors.shelley.CollateralIsScript.Error(failure)
+              } else if (errors.shelley.CollateralHasNonAdaAssets.assert(failure)) {
+                return new errors.shelley.CollateralHasNonAdaAssets.Error(failure)
+              } else if (errors.shelley.TooManyCollateralInputs.assert(failure)) {
+                return new errors.shelley.TooManyCollateralInputs.Error(failure)
+              } else if (errors.shelley.ExecutionUnitsTooLarge.assert(failure)) {
+                return new errors.shelley.ExecutionUnitsTooLarge.Error(failure)
+              } else if (errors.shelley.OutsideForecast.assert(failure)) {
+                return new errors.shelley.OutsideForecast.Error(failure)
+              } else if (errors.shelley.ValidationTagMismatch.assert(failure)) {
+                return new errors.shelley.ValidationTagMismatch.Error(failure)
+              } else if (errors.shelley.CollectErrors.assert(failure)) {
+                return new errors.shelley.CollectErrors.Error(failure)
               } else {
                 return new Error(failure)
               }

--- a/clients/TypeScript/packages/client/test/StateQuery.test.ts
+++ b/clients/TypeScript/packages/client/test/StateQuery.test.ts
@@ -1,16 +1,19 @@
 import {
   createStateQueryClient,
   currentEpoch,
-  currentProtocolParameters, delegationsAndRewards,
+  currentProtocolParameters,
+  delegationsAndRewards,
   eraStart,
   genesisConfig,
   ledgerTip,
   nonMyopicMemberRewards,
   proposedProtocolParameters,
-  stakeDistribution, StateQueryClient,
+  stakeDistribution,
+  StateQueryClient,
   utxo
 } from '@src/StateQuery'
 import {
+  DelegationsAndRewards,
   Hash16,
   Slot
 } from '@cardano-ogmios/schema'
@@ -163,7 +166,7 @@ describe('Local state queries', () => {
       it('fetches the current delegate and rewards for given stake key hashes', async () => {
         const stakeKeyHashes = ['7c16240714ea0e12b41a914f2945784ac494bb19573f0ca61a08afa8'] as Hash16[]
         const result = await delegationsAndRewards(stakeKeyHashes, { connection })
-        const item = result[stakeKeyHashes[0]]
+        const item = result[stakeKeyHashes[0]] as DelegationsAndRewards
         expect(item).toHaveProperty('delegate')
         expect(item).toHaveProperty('rewards')
       })

--- a/docs/static/ogmios.wsp.json
+++ b/docs/static/ogmios.wsp.json
@@ -889,10 +889,7 @@
         }
       , "result":
         { "oneOf":
-          [ { "type": "array"
-            , "title": "utxo"
-            , "items": { "$ref": "#/definitions/Utxo" }
-            }
+          [ { "$ref": "#/definitions/Utxo" }
           , { "$ref": "#/definitions/EraMismatch" }
           , { "$ref": "#/definitions/QueryUnavailableInCurrentEra" }
           ]
@@ -4223,9 +4220,13 @@
     { "type": "array"
     , "additionalItems": false
     , "items":
-      [ { "$ref": "#/definitions/TxIn" }
-      , { "$ref": "#/definitions/TxOut" }
-      ]
+      { "type": "array"
+      , "additionalItems": false
+      , "items":
+        [ { "$ref": "#/definitions/TxIn" }
+        , { "$ref": "#/definitions/TxOut" }
+        ]
+      }
     }
 
   , "UtxoValidationError":

--- a/docs/static/ogmios.wsp.json
+++ b/docs/static/ogmios.wsp.json
@@ -3019,6 +3019,43 @@
     , "pattern": "^[A-Za-z0-9+/]*=?=?$"
     }
 
+  , "ScriptPurpose":
+    { "oneOf":
+      [ { "title": "spend"
+        , "type": "object"
+        , "additionalProperties": false
+        , "required": [ "spend" ]
+        , "properties":
+          { "spend": { "$ref": "#/definitions/TxIn" }
+          }
+        }
+      , { "title": "mint"
+        , "type": "object"
+        , "additionalProperties": false
+        , "required": [ "mint" ]
+        , "properties":
+          { "mint": { "$ref": "#/definitions/Hash16" }
+          }
+        }
+      , { "title": "certificate"
+        , "type": "object"
+        , "additionalProperties": false
+        , "required": [ "certificate" ]
+        , "properties":
+          { "certificate": { "$ref": "#/definitions/Certificate" }
+          }
+        }
+      , { "title": "withdrawal"
+        , "type": "object"
+        , "additionalProperties": false
+        , "required": [ "withdrawal" ]
+        , "properties":
+          { "withdrawal": { "$ref": "#/definitions/RewardAccount" }
+          }
+        }
+      ]
+    }
+
   , "Signature":
     { "type": "string"
     , "contentEncoding": "base64"
@@ -3717,6 +3754,11 @@
     , "properties":
       { "unredeemableScripts":
         { "type": "array"
+        , "items":
+          { "type": "object"
+          , "additionalProperties": { "$ref": "#/definitions/ScriptPurpose" }
+          , "propertyNames": { "$ref": "#/definitions/Hash16" }
+          }
         }
       }
     }
@@ -3729,6 +3771,18 @@
     , "properties":
       { "datumsMismatch":
         { "type": "object"
+        , "additionalProperties": false
+        , "required": [ "provided", "inferredFromInputs" ]
+        , "properties":
+          { "provided":
+            { "type": "array"
+            , "items": { "$ref": "#/definitions/Hash16" }
+            }
+          , "inferredFromInputs":
+            { "type": "array"
+            , "items": { "$ref": "#/definitions/Hash16" }
+            }
+          }
         }
       }
     }
@@ -3741,6 +3795,22 @@
     , "properties":
       { "extraDataMismatch":
         { "type": "object"
+        , "additionalProperties": false
+        , "required": [ "provided", "inferredFromParameters" ]
+        , "properties":
+          { "provided":
+            { "oneOf":
+              [ { "$ref": "#/definitions/Hash16" }
+              , { "type": "null", "title": "null" }
+              ]
+            }
+          , "inferredFromParameters":
+            { "oneOf":
+              [ { "$ref": "#/definitions/Hash16" }
+              , { "type": "null", "title": "null" }
+              ]
+            }
+          }
         }
       }
     }
@@ -3753,6 +3823,7 @@
     , "properties":
       { "missingRequiredSignatures":
         { "type": "array"
+        , "items": { "$ref": "#/definitions/Hash16" }
         }
       }
     }
@@ -3765,6 +3836,12 @@
     , "properties":
       { "collateralTooSmall":
         { "type": "object"
+        , "additionalProperties": false
+        , "required": [ "requiredCollateral", "actualCollateral" ]
+        , "properties":
+          { "requiredCollateral": { "$ref": "#/definitions/Lovelace" }
+          , "actualCollateral": { "$ref": "#/definitions/Lovelace" }
+          }
         }
       }
     }
@@ -3775,9 +3852,7 @@
     , "additionalProperties": false
     , "required": [ "collateralIsScript" ]
     , "properties":
-      { "collateralIsScript":
-        { "type": "object"
-        }
+      { "collateralIsScript": { "$ref": "#/definitions/Utxo[Alonzo]" }
       }
     }
 
@@ -3787,9 +3862,7 @@
     , "additionalProperties": false
     , "required": [ "collateralHasNonAdaAssets" ]
     , "properties":
-      { "collateralHasNonAdaAssets":
-          { "type": "object"
-          }
+      { "collateralHasNonAdaAssets": { "$ref": "#/definitions/Value" }
       }
     }
 
@@ -3801,6 +3874,12 @@
     , "properties":
       { "tooManyCollateralInputs":
         { "type": "object"
+        , "additionalProperties": false
+        , "required": [ "maximumCollateralInputs", "actualCollateralInputs" ]
+        , "properties":
+          { "maximumCollateralInputs": { "type": "integer" }
+          , "actualCollateralInputs": { "type": "integer" }
+          }
         }
       }
     }
@@ -3813,6 +3892,12 @@
     , "properties":
       { "executionUnitsTooLarge":
         { "type": "object"
+        , "additionalProperties": false
+        , "required": [ "maximumExecutionUnits", "actualExecutionUnits" ]
+        , "properties":
+          { "maximumExecutionUnits": { "$ref": "#/definitions/ExUnits" }
+          , "actualExecutionUnits": { "$ref": "#/definitions/ExUnits" }
+          }
         }
       }
     }
@@ -3823,7 +3908,7 @@
     , "additionalProperties": false
     , "required": [ "outsideForecast" ]
     , "properties":
-      { "outsideForecast": { "$ref": "#/definitions/SlotNo" }
+      { "outsideForecast": { "$ref": "#/definitions/Slot" }
       }
     }
 
@@ -4150,6 +4235,15 @@
     , "items":
       [ { "$ref": "#/definitions/TxIn" }
       , { "$ref": "#/definitions/TxOut[Mary]" }
+      ]
+    }
+
+  , "Utxo[Alonzo]":
+    { "type": "array"
+    , "additionalItems": false
+    , "items":
+      [ { "$ref": "#/definitions/TxIn" }
+      , { "$ref": "#/definitions/TxOut[Alonzo]" }
       ]
     }
 

--- a/docs/static/ogmios.wsp.json
+++ b/docs/static/ogmios.wsp.json
@@ -885,12 +885,7 @@
         { "oneOf":
           [ { "type": "array"
             , "title": "utxo"
-            , "items":
-              { "oneOf":
-                  [ { "$ref": "#/definitions/Utxo" }
-                  , { "$ref": "#/definitions/Utxo[Mary]" }
-                  ]
-              }
+            , "items": { "$ref": "#/definitions/Utxo" }
             }
           , { "$ref": "#/definitions/EraMismatch" }
           , { "$ref": "#/definitions/QueryUnavailableInCurrentEra" }
@@ -1659,7 +1654,7 @@
                   }
                 , "outputs":
                   { "type": "array"
-                  , "items": { "$ref": "#/definitions/TxOut[Mary]" }
+                  , "items": { "$ref": "#/definitions/TxOut" }
                   }
                 , "certificates":
                   { "type": "array"
@@ -1740,7 +1735,7 @@
                   }
                 , "outputs":
                   { "type": "array"
-                  , "items": { "$ref": "#/definitions/TxOut[Alonzo]" }
+                  , "items": { "$ref": "#/definitions/TxOut" }
                   }
                 , "certificates":
                   { "type": "array"
@@ -3426,19 +3421,12 @@
   , "SubmitTxError[outputTooSmall]":
     { "type": "object"
     , "title": "outputTooSmall"
-    , "description": "Returns 'TxOut[Mary]' since Mary, and 'TxOut' before."
     , "additionalProperties": false
     , "required": [ "outputTooSmall" ]
     , "properties":
       { "outputTooSmall":
         { "type": "array"
-        , "items":
-          { "oneOf":
-              [ { "$ref": "#/definitions/TxOut" }
-              , { "$ref": "#/definitions/TxOut[Mary]" }
-              , { "$ref": "#/definitions/TxOut[Alonzo]" }
-              ]
-          }
+        , "items":{ "$ref": "#/definitions/TxOut" }
         }
       }
     }
@@ -3452,13 +3440,7 @@
     , "properties":
       { "tooManyAssetsInOutput":
         { "type": "array"
-        , "items":
-          { "oneOf":
-              [ { "$ref": "#/definitions/TxOut" }
-              , { "$ref": "#/definitions/TxOut[Mary]" }
-              , { "$ref": "#/definitions/TxOut[Alonzo]" }
-              ]
-          }
+        , "items": { "$ref": "#/definitions/TxOut" }
         }
       }
     }
@@ -3852,7 +3834,7 @@
     , "additionalProperties": false
     , "required": [ "collateralIsScript" ]
     , "properties":
-      { "collateralIsScript": { "$ref": "#/definitions/Utxo[Alonzo]" }
+      { "collateralIsScript": { "$ref": "#/definitions/Utxo" }
       }
     }
 
@@ -3989,28 +3971,39 @@
 
   , "TxOut":
     { "type": "object"
+    , "description": "A transaction output. Since Mary, 'value' always return a multi-asset value. Since Alonzo, 'datum' is always present (albeit sometimes 'null')"
+    , "examples":
+      [ { "address": "addr1kkhxvw4w4rjsq9tmma964lt0twsvu46e7lx5zq0uzvh4g7akg7z"
+        , "value": 1337
+        }
+      , { "address": "addr_test1kkhxvw4w4rjsq9tmma964lt0twsvu46e7lx5zq0uzvh4gacwqam"
+        , "value":
+          { "coins": 14
+          , "assets":
+            { "c3b87a742ad14abf855ebc6733081e3542acb3a64d80c29302260d62": 27
+            }
+          }
+        }
+      , { "address": "addr_test1qz66ue36465w2qq40005h2hadad6pnjht8mu6sgplsfj74qdjnshguewlx4ww0eet26y2pal4xpav5prcydf28cvxtjqx46x7f"
+        , "value":
+          { "coins": 2
+          , "assets":
+            { "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e": 1
+            , "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54": 2
+            }
+          }
+        , "datum": null
+        }
+      , { "address": "addr1pk2wzarn9mu64eel89dtg3g8h75c84jsy0q349glpsewg2x42k2"
+        , "value":
+          { "coins": 42
+          , "assets": {}
+          }
+        , "datum": "2a941b2a5460b760c6dd82fe08f2ca26896fde5f22bc0146409bd95c9b4c8446"
+        }
+      ]
     , "additionalProperties": false
     , "required": [ "address", "value" ]
-    , "properties":
-      { "address": { "$ref": "#/definitions/Address" }
-      , "value": { "$ref": "#/definitions/Lovelace" }
-      }
-    }
-
-  , "TxOut[Mary]":
-    { "type": "object"
-    , "additionalProperties": false
-    , "required": [ "address", "value" ]
-    , "properties":
-      { "address": { "$ref": "#/definitions/Address" }
-      , "value": { "$ref": "#/definitions/Value" }
-      }
-    }
-
-  , "TxOut[Alonzo]":
-    { "type": "object"
-    , "additionalProperties": false
-    , "required": [ "address", "value", "datum" ]
     , "properties":
       { "address": { "$ref": "#/definitions/Address" }
       , "value": { "$ref": "#/definitions/Value" }
@@ -4229,24 +4222,6 @@
       ]
     }
 
-  , "Utxo[Mary]":
-    { "type": "array"
-    , "additionalItems": false
-    , "items":
-      [ { "$ref": "#/definitions/TxIn" }
-      , { "$ref": "#/definitions/TxOut[Mary]" }
-      ]
-    }
-
-  , "Utxo[Alonzo]":
-    { "type": "array"
-    , "additionalItems": false
-    , "items":
-      [ { "$ref": "#/definitions/TxIn" }
-      , { "$ref": "#/definitions/TxOut[Alonzo]" }
-      ]
-    }
-
   , "UtxoValidationError":
     { "oneOf":
       [ { "type": "string"
@@ -4287,7 +4262,7 @@
   , "Value":
     { "type": "object"
     , "additionalProperties": false
-    , "required": [ "coins", "assets" ]
+    , "required": [ "coins" ]
     , "properties":
       { "coins": { "$ref": "#/definitions/Lovelace" }
       , "assets":

--- a/docs/static/ogmios.wsp.json
+++ b/docs/static/ogmios.wsp.json
@@ -776,8 +776,9 @@
         , "enum": [ "Query" ]
         }
       , "result":
-        { "oneOf":
+        { "anyOf":
           [ { "$ref": "#/definitions/ProtocolParameters[Shelley]" }
+          , { "$ref": "#/definitions/ProtocolParameters[Alonzo]" }
           , { "$ref": "#/definitions/EraMismatch" }
           , { "$ref": "#/definitions/QueryUnavailableInCurrentEra" }
           ]
@@ -810,11 +811,16 @@
         , "enum": [ "Query" ]
         }
       , "result":
-        { "oneOf":
+        { "anyOf":
           [ { "type": "object"
             , "title": "ProtocolParameters[Shelley]"
             , "propertyNames": { "contentEncoding": "bech32", "pattern": "^[0-9a-f]+$" }
             , "additionalProperties": { "$ref": "#/definitions/ProtocolParameters[Shelley]" }
+            }
+          , { "type": "object"
+            , "title": "ProtocolParameters[Alonzo]"
+            , "propertyNames": { "contentEncoding": "bech32", "pattern": "^[0-9a-f]+$" }
+            , "additionalProperties": { "$ref": "#/definitions/ProtocolParameters[Alonzo]" }
             }
           , { "$ref": "#/definitions/EraMismatch" }
           , { "$ref": "#/definitions/QueryUnavailableInCurrentEra" }

--- a/docs/static/ogmios.wsp.json
+++ b/docs/static/ogmios.wsp.json
@@ -1271,10 +1271,9 @@
               }
             , "witness":
               { "signatures":
-                [ { "386020d73807f285ba3259efacd9fbea1939ebd97dc2ddc3b178d427e5a047f6": "5bckfySir7f4G+SV83UPw0+42qqFcEU+sdmK+uejnx6gn6OFMckasHBY8xPWabJ9w5xMmD8sRJ5VC7bNsUU0Ag=="
-                  , "de735ba8771f521b50bc3130c4a7d6f0784df718d3ed3ca32befd9a4650c2e8a": "KHlV88SX+sODj4EqHW7U1wxLL2nVuq/wg43rdaarckroEZc3k1h7YcH0CyAoBvy5+xv6aZ6clDvceeUliD6RCw=="
-                  }
-                ]
+                { "386020d73807f285ba3259efacd9fbea1939ebd97dc2ddc3b178d427e5a047f6": "5bckfySir7f4G+SV83UPw0+42qqFcEU+sdmK+uejnx6gn6OFMckasHBY8xPWabJ9w5xMmD8sRJ5VC7bNsUU0Ag=="
+                , "de735ba8771f521b50bc3130c4a7d6f0784df718d3ed3ca32befd9a4650c2e8a": "KHlV88SX+sODj4EqHW7U1wxLL2nVuq/wg43rdaarckroEZc3k1h7YcH0CyAoBvy5+xv6aZ6clDvceeUliD6RCw=="
+                }
               , "scripts": {}
               , "bootstrap": []
               }
@@ -1351,8 +1350,9 @@
               , "required": ["signatures","scripts","bootstrap"]
               , "properties":
                 { "signatures":
-                  { "type": "array"
-                  , "items": { "$ref": "#/definitions/Signature" }
+                  { "type": "object"
+                  , "propertyNames": { "contentEncoding": "base16", "pattern": "^[0-9a-f]+$" }
+                  , "additionalProperties": { "$ref": "#/definitions/Signature" }
                   }
                 , "scripts":
                   { "type": "object"
@@ -1434,10 +1434,9 @@
               }
             , "witness":
               { "signatures":
-                [ { "386020d73807f285ba3259efacd9fbea1939ebd97dc2ddc3b178d427e5a047f6": "5bckfySir7f4G+SV83UPw0+42qqFcEU+sdmK+uejnx6gn6OFMckasHBY8xPWabJ9w5xMmD8sRJ5VC7bNsUU0Ag=="
-                  , "de735ba8771f521b50bc3130c4a7d6f0784df718d3ed3ca32befd9a4650c2e8a": "KHlV88SX+sODj4EqHW7U1wxLL2nVuq/wg43rdaarckroEZc3k1h7YcH0CyAoBvy5+xv6aZ6clDvceeUliD6RCw=="
-                  }
-                ]
+                { "386020d73807f285ba3259efacd9fbea1939ebd97dc2ddc3b178d427e5a047f6": "5bckfySir7f4G+SV83UPw0+42qqFcEU+sdmK+uejnx6gn6OFMckasHBY8xPWabJ9w5xMmD8sRJ5VC7bNsUU0Ag=="
+                , "de735ba8771f521b50bc3130c4a7d6f0784df718d3ed3ca32befd9a4650c2e8a": "KHlV88SX+sODj4EqHW7U1wxLL2nVuq/wg43rdaarckroEZc3k1h7YcH0CyAoBvy5+xv6aZ6clDvceeUliD6RCw=="
+                }
               , "scripts": {}
               , "bootstrap": []
               }
@@ -1514,8 +1513,9 @@
               , "required": ["signatures","scripts","bootstrap"]
               , "properties":
                 { "signatures":
-                  { "type": "array"
-                  , "items": { "$ref": "#/definitions/Signature" }
+                  { "type": "object"
+                  , "propertyNames": { "contentEncoding": "base16", "pattern": "^[0-9a-f]+$" }
+                  , "additionalProperties": { "$ref": "#/definitions/Signature" }
                   }
                 , "scripts":
                   { "type": "object"
@@ -1585,10 +1585,9 @@
               }
             , "witness":
               { "signatures":
-                [ { "a900560b6c0964492849eb5311acac881edeb8d2282122b895fd418243c92f4e": "3TLin5vgz4dQDomhMjW9q4VIQD/X6Q9ECWkA8kVOz/c8R2c4mO1P1+LD/9n2ouHOANNC5ZgzwV2ojAVpZw4IBA=="
-                  , "5c19b9b0dd58b782dcac33cdc925f74c1385d8aae5912f7e1040a2d24a47e4eb": "qjqis5n/XGVp5PCIe0h8h/+ZO6rdIClBfzb7SEaaG4kAuY+zMAnfA57oxcLI6MA81rJ/nVct7FDtLKEHjimlDg=="
-                  }
-                ]
+                { "a900560b6c0964492849eb5311acac881edeb8d2282122b895fd418243c92f4e": "3TLin5vgz4dQDomhMjW9q4VIQD/X6Q9ECWkA8kVOz/c8R2c4mO1P1+LD/9n2ouHOANNC5ZgzwV2ojAVpZw4IBA=="
+                , "5c19b9b0dd58b782dcac33cdc925f74c1385d8aae5912f7e1040a2d24a47e4eb": "qjqis5n/XGVp5PCIe0h8h/+ZO6rdIClBfzb7SEaaG4kAuY+zMAnfA57oxcLI6MA81rJ/nVct7FDtLKEHjimlDg=="
+                }
               , "scripts": {}
               , "bootstrap": []
               }
@@ -1679,8 +1678,9 @@
               , "required": ["signatures","scripts","bootstrap"]
               , "properties":
                 { "signatures":
-                  { "type": "array"
-                  , "items": { "$ref": "#/definitions/Signature" }
+                  { "type": "object"
+                  , "propertyNames": { "contentEncoding": "base16", "pattern": "^[0-9a-f]+$" }
+                  , "additionalProperties": { "$ref": "#/definitions/Signature" }
                   }
                 , "scripts":
                   { "type": "object"
@@ -1785,8 +1785,9 @@
               , "required": ["signatures","scripts","bootstrap", "datums", "redeemers"]
               , "properties":
                 { "signatures":
-                  { "type": "array"
-                  , "items": { "$ref": "#/definitions/Signature" }
+                  { "type": "object"
+                  , "propertyNames": { "contentEncoding": "base16", "pattern": "^[0-9a-f]+$" }
+                  , "additionalProperties": { "$ref": "#/definitions/Signature" }
                   }
                 , "scripts":
                   { "type": "object"
@@ -2169,7 +2170,7 @@
 
   , "CostModels":
     { "type": "object"
-    , "additionalProperties": { "$ref": "#/definition/CostModel" }
+    , "additionalProperties": { "$ref": "#/definitions/CostModel" }
     , "propertyNames": { "enum": [ "plutus:v1" ] }
     , "examples":
       [ { "plutus:v1":
@@ -3019,9 +3020,9 @@
     }
 
   , "Signature":
-    { "type": "object"
-    , "additionalProperties": { "$ref": "#/definitions/Hash64" }
-    , "propertyNames": { "contentEncoding": "base16", "pattern": "^[0-9a-f]+$" }
+    { "type": "string"
+    , "contentEncoding": "base64"
+    , "pattern": "^[A-Za-z0-9+/]*=?=?$"
     }
 
   , "Slot":

--- a/docs/static/ogmios.wsp.json
+++ b/docs/static/ogmios.wsp.json
@@ -392,7 +392,7 @@
                 , "additionalProperties": false
                 , "required": ["failure"]
                 , "properties":
-                  { "failure": { "$ref": "#/definitions/AcquireFailure" }
+                  { "failure": { "$ref": "#/definitions/AcquireFailureDetails" }
                   }
                 }
               }
@@ -499,19 +499,19 @@
           { "query":
             { "oneOf":
               [ { "type": "string"
-                , "title": "eraStart"
+                , "title": "GetEraStart"
                 , "enum": ["eraStart"]
                 }
               , { "type": "string"
-                , "title": "ledgerTip"
+                , "title": "GetLedgerTip"
                 , "enum": ["ledgerTip"]
                 }
               , { "type": "string"
-                , "title": "currentEpoch"
+                , "title": "GetCurrentEpoch"
                 , "enum": ["currentEpoch"]
                 }
               , { "type": "object"
-                , "title": "nonMyopicMemberRewards"
+                , "title": "GetNonMyopicMemberRewards"
                 , "additionalProperties": false
                 , "required": ["nonMyopicMemberRewards"]
                 , "properties":
@@ -530,7 +530,7 @@
                   }
                 }
               , { "type": "object"
-                , "title": "delegationsAndRewards"
+                , "title": "GetDelegationsAndRewards"
                 , "additionalProperties": false
                 , "required": ["delegationsAndRewards"]
                 , "properties":
@@ -541,23 +541,23 @@
                   }
                 }
               , { "type": "string"
-                , "title": "currentProtocolParameters"
+                , "title": "GetCurrentProtocolParameters"
                 , "enum": ["currentProtocolParameters"]
                 }
               , { "type": "string"
-                , "title": "proposedProtocolParameters"
+                , "title": "GetProposedProtocolParameters"
                 , "enum": ["proposedProtocolParameters"]
                 }
               , { "type": "string"
-                , "title": "stakeDistribution"
+                , "title": "GetStakeDistribution"
                 , "enum": ["stakeDistribution"]
                 }
               , { "type": "string"
-                , "title": "utxo"
+                , "title": "GetUtxo"
                 , "enum": ["utxo"]
                 }
               , { "type": "object"
-                , "title": "utxo[filtered]"
+                , "title": "GetUtxo[filtered]"
                 , "additionalProperties": false
                 , "required": ["utxo"]
                 , "properties":
@@ -568,7 +568,7 @@
                   }
                 }
               , { "type": "string"
-                , "title": "genesisConfig"
+                , "title": "GetGenesisConfig"
                 , "enum": ["genesisConfig"]
                 }
               ]
@@ -742,7 +742,7 @@
           [ { "type": "object"
             , "additionalProperties": { "$ref": "#/definitions/DelegationsAndRewards" }
             , "propertyNames": { "pattern": "^[0-9]+|[0-9a-f]+$" }
-            , "title": "DelegationsAndRewards"
+            , "title": "DelegationsAndRewardsByAccounts"
             }
           , { "$ref": "#/definitions/EraMismatch" }
           , { "$ref": "#/definitions/QueryUnavailableInCurrentEra" }
@@ -983,7 +983,7 @@
   }
 
 , "definitions":
-  { "AcquireFailure":
+  { "AcquireFailureDetails":
     { "type": "string"
     , "enum": [ "pointTooOld", "pointNotOnChain" ]
     }
@@ -1180,9 +1180,9 @@
                 , "properties":
                   { "proposal":
                     { "oneOf":
-                      [ { "type": "null", "title": "null" }
+                      [ { "$ref": "#/definitions/Null"}
                       , { "type": "object"
-                        , "title": "proposal"
+                        , "title": "UpdateProposal[Byron]"
                         , "additionalProperties": false
                         , "required": [ "body", "issuer", "signature" ]
                         , "properties":
@@ -1366,7 +1366,7 @@
             , "metadata":
               { "oneOf":
                 [ { "$ref": "#/definitions/AuxiliaryData" }
-                , { "type": "null", "title": "null" }
+                , { "$ref": "#/definitions/Null"}
                 ]
               }
             }
@@ -1529,7 +1529,7 @@
             , "metadata":
               { "oneOf":
                 [ { "$ref": "#/definitions/AuxiliaryData" }
-                , { "type": "null", "title": "null" }
+                , { "$ref": "#/definitions/Null"}
                 ]
               }
             }
@@ -1694,7 +1694,7 @@
             , "metadata":
               { "oneOf":
                 [ { "$ref": "#/definitions/AuxiliaryData" }
-                , { "type": "null", "title": "null" }
+                , { "$ref": "#/definitions/Null"}
                 ]
               }
             }
@@ -1762,13 +1762,13 @@
                 , "network":
                   { "oneOf":
                     [ { "$ref": "#/definitions/Network" }
-                    , { "title": "null", "type": "null" }
+                    , { "$ref": "#/definitions/Null"}
                     ]
                   }
                 , "requiredExtraData":
                   { "oneOf":
                     [ { "$ref": "#/definitions/Hash16" }
-                    , { "title": "null", "type": "null" }
+                    , { "$ref": "#/definitions/Null"}
                     ]
                   }
                 , "requiredExtraSignatures":
@@ -1811,7 +1811,7 @@
             , "metadata":
               { "oneOf":
                 [ { "$ref": "#/definitions/AuxiliaryData" }
-                , { "type": "null", "title": "null" }
+                , { "$ref": "#/definitions/Null"}
                 ]
               }
             }
@@ -1887,13 +1887,13 @@
       , "chainCode":
         { "oneOf":
           [ { "$ref": "#/definitions/Hash16" }
-          , { "type": "null", "title": "null" }
+          , { "$ref": "#/definitions/Null"}
           ]
         }
       , "addressAttributes":
         { "oneOf":
           [ { "$ref": "#/definitions/Hash64" }
-          , { "type": "null", "title": "null" }
+          , { "$ref": "#/definitions/Null"}
           ]
         }
       , "key": { "$ref": "#/definitions/Hash16" }
@@ -1985,7 +1985,7 @@
               , "vrf": { "$ref": "#/definitions/Hash16" }
               , "metadata":
                 { "oneOf":
-                  [ { "type": "null", "title": "null" }
+                  [ { "$ref": "#/definitions/Null"}
                   , { "type": "object"
                     , "title": "metadata"
                     , "additionalProperties": false
@@ -2233,7 +2233,7 @@
 
   , "Era":
     { "type": "string"
-    , "enum": ["Byron", "Shelley", "Allegra", "Mary"]
+    , "enum": ["Byron", "Shelley", "Allegra", "Mary", "Alonzo"]
     }
 
   , "EraMismatch":
@@ -2559,24 +2559,28 @@
       ]
     }
 
+  , "Null":
+    { "type": "null"
+    }
+
   , "NullableInteger":
     { "oneOf":
       [ { "type": "integer", "title": "integer" }
-      , { "type": "null", "title": "null" }
+      , { "$ref": "#/definitions/Null"}
       ]
     }
 
   , "NullableNumber":
     { "oneOf":
       [ { "type": "number", "title": "integer" }
-      , { "type": "null", "title": "null" }
+      , { "$ref": "#/definitions/Null"}
       ]
     }
 
   , "NullableRatio":
     { "oneOf":
       [ { "$ref": "#/definitions/Ratio" }
-      , { "type": "null", "title": "null" }
+      , { "$ref": "#/definitions/Null"}
       ]
     }
 
@@ -2682,13 +2686,13 @@
       , "txFeePolicy":
         { "oneOf":
           [ { "$ref": "#/definitions/TxFeePolicy" }
-          , { "type": "null", "title": "null" }
+          , { "$ref": "#/definitions/Null"}
           ]
         }
       , "softforkRule":
         { "oneOf":
           [ { "$ref": "#/definitions/SoftForkRule" }
-          , { "type": "null", "title": "null" }
+          , { "$ref": "#/definitions/Null"}
           ]
         }
       }
@@ -2716,13 +2720,13 @@
       , "extraEntropy":
         { "oneOf":
           [ { "$ref": "#/definitions/Nonce" }
-          , { "type": "null", "title": "null" }
+          , { "$ref": "#/definitions/Null"}
           ]
         }
       , "protocolVersion":
         { "oneOf":
           [ { "$ref": "#/definitions/ProtocolVersion" }
-          , { "type": "null", "title": "null" }
+          , { "$ref": "#/definitions/Null"}
           ]
         }
       }
@@ -2753,37 +2757,37 @@
       , "extraEntropy":
         { "oneOf":
           [ { "$ref": "#/definitions/Nonce" }
-          , { "type": "null", "title": "null" }
+          , { "$ref": "#/definitions/Null"}
           ]
         }
       , "protocolVersion":
         { "oneOf":
           [ { "$ref": "#/definitions/ProtocolVersion" }
-          , { "type": "null", "title": "null" }
+          , { "$ref": "#/definitions/Null"}
           ]
         }
       , "costModels":
         { "oneOf":
           [ { "$ref": "#/definitions/CostModels" }
-          , { "type": "null", "title": "null" }
+          , { "$ref": "#/definitions/Null"}
           ]
         }
       , "prices":
         { "oneOf":
           [ { "$ref": "#/definitions/Prices" }
-          , { "type": "null", "title": "null" }
+          , { "$ref": "#/definitions/Null"}
           ]
         }
       , "maxExecutionUnitsPerTransaction":
         { "oneOf":
           [ { "$ref": "#/definitions/ExUnits" }
-          , { "type": "null", "title": "null" }
+          , { "$ref": "#/definitions/Null"}
           ]
         }
       , "maxExecutionUnitsPerBlock":
         { "oneOf":
           [ { "$ref": "#/definitions/ExUnits" }
-          , { "type": "null", "title": "null" }
+          , { "$ref": "#/definitions/Null"}
           ]
         }
       }
@@ -2858,13 +2862,13 @@
           { "ipv4":
             { "oneOf":
               [ { "type": "string", "title": "ip" }
-              , { "type": "null", "title": "null" }
+              , { "$ref": "#/definitions/Null"}
               ]
             }
           , "ipv6":
             { "oneOf":
               [ { "type": "string", "title": "ip" }
-              , { "type": "null", "title": "null" }
+              , { "$ref": "#/definitions/Null"}
               ]
             }
           , "port": { "$ref": "#/definitions/NullableInteger" }
@@ -3786,13 +3790,13 @@
           { "provided":
             { "oneOf":
               [ { "$ref": "#/definitions/Hash16" }
-              , { "type": "null", "title": "null" }
+              , { "$ref": "#/definitions/Null"}
               ]
             }
           , "inferredFromParameters":
             { "oneOf":
               [ { "$ref": "#/definitions/Hash16" }
-              , { "type": "null", "title": "null" }
+              , { "$ref": "#/definitions/Null"}
               ]
             }
           }
@@ -3899,6 +3903,7 @@
 
   , "SubmitTxError[validationTagMismatch]":
     { "type": "string"
+    , "title": "validationTagMismatch"
     , "enum": [ "validationTagMismatch" ]
     }
 
@@ -4013,7 +4018,7 @@
       , "datum":
         { "oneOf":
           [ { "$ref": "#/definitions/DatumHash" }
-          , { "title": "null", "type": "null" }
+          , { "$ref": "#/definitions/Null"}
           ]
         }
       }
@@ -4026,7 +4031,7 @@
         , "enum": [ "unknownAttributes", "unknownAddressAttributes" ]
         }
       , { "type": "object"
-        , "title": "feeTooSmall"
+        , "title": "feeTooSmall_"
         , "additionalProperties": false
         , "required": [ "feeTooSmall" ]
         , "properties":
@@ -4043,7 +4048,7 @@
           }
         }
       , { "type": "object"
-        , "title": "txTooLarge"
+        , "title": "txTooLarge_"
         , "additionalProperties": false
         , "required": [ "txTooLarge" ]
         , "properties":
@@ -4059,7 +4064,7 @@
           }
         }
       , { "type": "object"
-        , "title": "missingInput"
+        , "title": "missingInput_"
         , "additionalProperties": false
         , "required": [ "missingInput" ]
         , "properties":
@@ -4075,7 +4080,7 @@
           }
         }
       , { "type": "object"
-        , "title": "networkMismatch"
+        , "title": "networkMismatch_"
         , "additionalProperties": false
         , "required": [ "networkMismatch" ]
         , "properties":
@@ -4091,7 +4096,7 @@
           }
         }
       , { "type": "object"
-        , "title": "wrongSignature"
+        , "title": "wrongSignature_"
         , "additionalProperties": false
         , "required": [ "wrongSignature" ]
         , "properties":
@@ -4107,7 +4112,7 @@
           }
         }
       , { "type": "object"
-        , "title": "lovelaceError"
+        , "title": "lovelaceError_"
         , "additionalProperties": false
         , "required": [ "lovelaceError" ]
         , "properties":
@@ -4123,7 +4128,7 @@
           }
         }
       , { "type": "object"
-        , "title": "wrongKey"
+        , "title": "wrongKey_"
         , "additionalProperties": false
         , "required": [ "wrongKey" ]
         , "properties":
@@ -4179,9 +4184,9 @@
 
   , "Update[Shelley]":
     { "oneOf":
-      [ { "type": "null", "title": "null" }
+      [ { "$ref": "#/definitions/Null"}
       , { "type": "object"
-        , "title": "proposal"
+        , "title": "UpdateProposal[Shelley]"
         , "required": ["proposal", "epoch"]
         , "properties":
           { "epoch": { "$ref": "#/definitions/Epoch" }
@@ -4196,9 +4201,9 @@
 
   , "Update[Alonzo]":
     { "oneOf":
-      [ { "type": "null", "title": "null" }
+      [ { "$ref": "#/definitions/Null"}
       , { "type": "object"
-        , "title": "proposal"
+        , "title": "UpdateProposal[Alonzo]"
         , "required": ["proposal", "epoch"]
         , "properties":
           { "epoch": { "$ref": "#/definitions/Epoch" }
@@ -4222,6 +4227,8 @@
     , "items":
       { "type": "array"
       , "additionalItems": false
+      , "minItems": 2
+      , "maxItems": 2
       , "items":
         [ { "$ref": "#/definitions/TxIn" }
         , { "$ref": "#/definitions/TxOut" }
@@ -4254,13 +4261,13 @@
       { "invalidBefore":
           { "oneOf":
             [ { "$ref": "#/definitions/Slot" }
-            , { "type": "null", "title": "null" }
+            , { "$ref": "#/definitions/Null"}
             ]
           }
       , "invalidHereafter":
           { "oneOf":
             [ { "$ref": "#/definitions/Slot" }
-            , { "type": "null", "title": "null" }
+            , { "$ref": "#/definitions/Null"}
             ]
           }
       }

--- a/docs/static/ogmios.wsp.json
+++ b/docs/static/ogmios.wsp.json
@@ -1025,6 +1025,10 @@
         { "type": "array"
         , "items": { "$ref": "#/definitions/Script" }
         }
+      , "datums":
+        { "type": "array"
+        , "items": { "$ref": "#/definitions/Datum" }
+        }
       }
     }
 
@@ -1357,26 +1361,7 @@
                   }
                 , "bootstrap":
                   { "type": "array"
-                  , "items":
-                    { "type": "object"
-                    , "additionalProperties": false
-                    , "properties":
-                      { "signature": { "$ref": "#/definitions/Hash64" }
-                      , "chainCode":
-                        { "oneOf":
-                          [ { "$ref": "#/definitions/Hash16" }
-                          , { "type": "null", "title": "null" }
-                          ]
-                        }
-                      , "addressAttributes":
-                        { "oneOf":
-                          [ { "$ref": "#/definitions/Hash64" }
-                          , { "type": "null", "title": "null" }
-                          ]
-                        }
-                      , "key": { "$ref": "#/definitions/Hash16" }
-                      }
-                    }
+                  , "items": { "$ref": "#/definitions/BootstrapWitness" }
                   }
                 }
               }
@@ -1539,26 +1524,7 @@
                   }
                 , "bootstrap":
                   { "type": "array"
-                  , "items":
-                    { "type": "object"
-                    , "additionalProperties": false
-                    , "properties":
-                      { "signature": { "$ref": "#/definitions/Hash64" }
-                      , "chainCode":
-                        { "oneOf":
-                          [ { "$ref": "#/definitions/Hash16" }
-                          , { "type": "null", "title": "null" }
-                          ]
-                        }
-                      , "addressAttributes":
-                        { "oneOf":
-                          [ { "$ref": "#/definitions/Hash64" }
-                          , { "type": "null", "title": "null" }
-                          ]
-                        }
-                      , "key": { "$ref": "#/definitions/Hash16" }
-                      }
-                    }
+                  , "items": { "$ref": "#/definitions/BootstrapWitness" }
                   }
                 }
               }
@@ -1723,26 +1689,7 @@
                   }
                 , "bootstrap":
                   { "type": "array"
-                  , "items":
-                    { "type": "object"
-                    , "additionalProperties": false
-                    , "properties":
-                      { "signature": { "$ref": "#/definitions/Hash64" }
-                      , "chainCode":
-                        { "oneOf":
-                          [ { "$ref": "#/definitions/Hash16" }
-                          , { "type": "null", "title": "null" }
-                          ]
-                        }
-                      , "addressAttributes":
-                        { "oneOf":
-                          [ { "$ref": "#/definitions/Hash64" }
-                          , { "type": "null", "title": "null" }
-                          ]
-                        }
-                      , "key": { "$ref": "#/definitions/Hash16" }
-                      }
-                    }
+                  , "items": { "$ref": "#/definitions/BootstrapWitness" }
                   }
                 }
               }
@@ -1777,7 +1724,11 @@
             , "body":
               { "type": "object"
               , "additionalProperties": false
-              , "required": ["inputs","outputs","certificates","withdrawals","fee","validityInterval","mint","update"]
+              , "required":
+                [ "inputs", "collaterals", "outputs", "certificates"
+                , "withdrawals", "fee", "validityInterval", "update", "mint"
+                , "network", "requiredExtraData", "requiredExtraSignatures"
+                ]
               , "properties":
                 { "inputs":
                   { "type": "array"
@@ -1811,12 +1762,15 @@
                   { "$ref": "#/definitions/Value"
                   }
                 , "network":
-                  { "$ref": "#/definitions/Network"
+                  { "oneOf":
+                    [ { "$ref": "#/definitions/Network" }
+                    , { "title": "null", "type": "null" }
+                    ]
                   }
                 , "requiredExtraData":
                   { "oneOf":
                     [ { "$ref": "#/definitions/Hash16" }
-                    , { "title": null, "type": "null" }
+                    , { "title": "null", "type": "null" }
                     ]
                   }
                 , "requiredExtraSignatures":
@@ -1828,7 +1782,7 @@
             , "witness":
               { "type": "object"
               , "additionalProperties": false
-              , "required": ["signatures","scripts","bootstrap"]
+              , "required": ["signatures","scripts","bootstrap", "datums", "redeemers"]
               , "properties":
                 { "signatures":
                   { "type": "array"
@@ -1841,26 +1795,17 @@
                   }
                 , "bootstrap":
                   { "type": "array"
-                  , "items":
-                    { "type": "object"
-                    , "additionalProperties": false
-                    , "properties":
-                      { "signature": { "$ref": "#/definitions/Hash64" }
-                      , "chainCode":
-                        { "oneOf":
-                          [ { "$ref": "#/definitions/Hash16" }
-                          , { "type": "null", "title": "null" }
-                          ]
-                        }
-                      , "addressAttributes":
-                        { "oneOf":
-                          [ { "$ref": "#/definitions/Hash64" }
-                          , { "type": "null", "title": "null" }
-                          ]
-                        }
-                      , "key": { "$ref": "#/definitions/Hash16" }
-                      }
-                    }
+                  , "items": { "$ref": "#/definitions/BootstrapWitness" }
+                  }
+                , "datums":
+                  { "type": "object"
+                  , "propertyNames": { "contentEncoding": "base16", "pattern": "^[0-9a-f]+$" }
+                  , "additionalProperties": { "$ref": "#/definitions/Hash64" }
+                  }
+                , "redeemers":
+                  { "type": "object"
+                  , "propertyNames": { "$ref": "#/definitions/RedeemerPointer" }
+                  , "additionalProperties": { "$ref": "#/definitions/Redeemer" }
                   }
                 }
               }
@@ -1921,6 +1866,39 @@
     { "type": "integer"
     , "description": "The size of the block in bytes."
     , "minimum": 0
+    }
+
+  , "BootstrapWitness":
+    { "type": "object"
+    , "examples":
+      [ { "signature": "ZGdic3hnZ3RvZ2hkanB0ZXR2dGtjb2N2eWZpZHFxZ2d1cmpocmhxYWlpc3BxcnVlbGh2eXBxeGVld3ByeWZ2dw=="
+        , "key": "deeb8f82f2af5836ebbc1b450b6dbf0b03c93afe5696f10d49e8a8304ebfac01"
+        , "addressAttributes": "cA=="
+        , "chainCode": "b6dbf0b03c93afe5696f10d49e8a8304ebfac01deeb8f82f2af5836ebbc1b450"
+        }
+      , { "signature": "KYCDveFX76KYEg6Axad/RG5+b5QbJdtYQSNA6kPjqsHh5cIwYPQyqquLJcwo9uDDfqUNmu7n2NUG+o7t2a1Hjg=="
+        , "key": "0c02af01eaacc939b3d0d817f4eb57d323ea5686cb1fecb8de821df1296b84a7"
+        , "chainCode": null
+        , "addressAttributes": null
+        }
+      ]
+    , "additionalProperties": false
+    , "properties":
+      { "signature": { "$ref": "#/definitions/Hash64" }
+      , "chainCode":
+        { "oneOf":
+          [ { "$ref": "#/definitions/Hash16" }
+          , { "type": "null", "title": "null" }
+          ]
+        }
+      , "addressAttributes":
+        { "oneOf":
+          [ { "$ref": "#/definitions/Hash64" }
+          , { "type": "null", "title": "null" }
+          ]
+        }
+      , "key": { "$ref": "#/definitions/Hash16" }
+      }
     }
 
   , "Bound":
@@ -2207,10 +2185,16 @@
     , "additionalProperties": { "type": "integer" }
     }
 
+  , "Datum":
+    { "type": "string"
+    , "contentEncoding": "base64"
+    , "pattern": "^[A-Za-z0-9+/]*=?=?$"
+    }
+
   , "DatumHash":
     { "type": "string"
     , "contentEncoding": "base16"
-    , "pattern": "^[0-9a-f]$"
+    , "pattern": "^[0-9a-f]+$"
     }
 
   , "DelegationsAndRewards":
@@ -2831,6 +2815,29 @@
       [ "2/3"
       , "7/8"
       ]
+    }
+
+  , "Redeemer":
+    { "type": "object"
+    , "examples":
+      [ { "executionUnits":
+          { "memory": 2
+          , "steps": 2
+          }
+        , "redeemer": "ggRCqSQ="
+        }
+      ]
+    , "additionalProperties": false
+    , "required": [ "redeemer", "executionUnits" ]
+    , "properties":
+      { "redeemer": { "$ref": "#/definitions/Hash64" }
+      , "executionUnits": { "$ref": "#/definitions/ExUnits" }
+      }
+    }
+
+  , "RedeemerPointer":
+    { "type": "string"
+    , "pattern": "^(spend|mint|certificate|withdrawal):[0-9]+$"
     }
 
   , "RelativeTime":
@@ -3770,11 +3777,16 @@
   , "TxOut[Alonzo]":
     { "type": "object"
     , "additionalProperties": false
-    , "required": [ "address", "value" ]
+    , "required": [ "address", "value", "datum" ]
     , "properties":
       { "address": { "$ref": "#/definitions/Address" }
       , "value": { "$ref": "#/definitions/Value" }
-      , "datum": { "$ref": "#/definitions/DatumHash" }
+      , "datum":
+        { "oneOf":
+          [ { "$ref": "#/definitions/DatumHash" }
+          , { "title": "null", "type": "null" }
+          ]
+        }
       }
     }
 

--- a/docs/static/ogmios.wsp.json
+++ b/docs/static/ogmios.wsp.json
@@ -1062,6 +1062,14 @@
           { "mary": { "$ref": "#/definitions/Block[Mary]" }
           }
         }
+      , { "type": "object"
+        , "required": [ "alonzo" ]
+        , "title": "alonzo"
+        , "additionalProperties": false
+        , "properties":
+          { "alonzo": { "$ref": "#/definitions/Block[Alonzo]" }
+          }
+        }
       ]
     }
 
@@ -1752,6 +1760,124 @@
       }
     }
 
+  , "Block[Alonzo]":
+    { "type": "object"
+    , "additionalProperties": false
+    , "examples": []
+    , "properties":
+      { "body":
+        { "type": "array"
+        , "items":
+          { "type": "object"
+          , "additionalProperties": false
+          , "required": [ "id", "body", "witness", "metadata" ]
+          , "$omitted-if-compact": ["witness"]
+          , "properties":
+            { "id": { "$ref": "#/definitions/Hash16" }
+            , "body":
+              { "type": "object"
+              , "additionalProperties": false
+              , "required": ["inputs","outputs","certificates","withdrawals","fee","validityInterval","mint","update"]
+              , "properties":
+                { "inputs":
+                  { "type": "array"
+                  , "items": { "$ref": "#/definitions/TxIn" }
+                  }
+                , "collaterals":
+                  { "type": "array"
+                  , "items": { "$ref": "#/definitions/TxIn" }
+                  }
+                , "outputs":
+                  { "type": "array"
+                  , "items": { "$ref": "#/definitions/TxOut[Alonzo]" }
+                  }
+                , "certificates":
+                  { "type": "array"
+                  , "items": { "$ref": "#/definitions/Certificate" }
+                  }
+                , "withdrawals":
+                  { "$ref": "#/definitions/Withdrawals"
+                  }
+                , "fee":
+                  { "$ref": "#/definitions/Lovelace"
+                  }
+                , "validityInterval":
+                  { "$ref": "#/definitions/ValidityInterval"
+                  }
+                , "update":
+                  { "$ref": "#/definitions/Update[Alonzo]"
+                  }
+                , "mint":
+                  { "$ref": "#/definitions/Value"
+                  }
+                , "network":
+                  { "$ref": "#/definitions/Network"
+                  }
+                , "requiredExtraData":
+                  { "oneOf":
+                    [ { "$ref": "#/definitions/Hash16" }
+                    , { "title": null, "type": "null" }
+                    ]
+                  }
+                , "requiredExtraSignatures":
+                  { "type": "array"
+                  , "items": { "$ref": "#/definitions/Hash16" }
+                  }
+                }
+              }
+            , "witness":
+              { "type": "object"
+              , "additionalProperties": false
+              , "required": ["signatures","scripts","bootstrap"]
+              , "properties":
+                { "signatures":
+                  { "type": "array"
+                  , "items": { "$ref": "#/definitions/Signature" }
+                  }
+                , "scripts":
+                  { "type": "object"
+                  , "propertyNames": { "contentEncoding": "base16", "pattern": "^[0-9a-f]+$" }
+                  , "additionalProperties": { "$ref": "#/definitions/Script" }
+                  }
+                , "bootstrap":
+                  { "type": "array"
+                  , "items":
+                    { "type": "object"
+                    , "additionalProperties": false
+                    , "properties":
+                      { "signature": { "$ref": "#/definitions/Hash64" }
+                      , "chainCode":
+                        { "oneOf":
+                          [ { "$ref": "#/definitions/Hash16" }
+                          , { "type": "null", "title": "null" }
+                          ]
+                        }
+                      , "addressAttributes":
+                        { "oneOf":
+                          [ { "$ref": "#/definitions/Hash64" }
+                          , { "type": "null", "title": "null" }
+                          ]
+                        }
+                      , "key": { "$ref": "#/definitions/Hash16" }
+                      }
+                    }
+                  }
+                }
+              }
+            , "metadata":
+              { "oneOf":
+                [ { "$ref": "#/definitions/AuxiliaryData" }
+                , { "type": "null", "title": "null" }
+                ]
+              }
+            }
+          }
+        }
+      , "headerHash": { "$ref": "#/definitions/Block[Shelley]/properties/headerHash" }
+      , "header": { "$ref": "#/definitions/Block[Shelley]/properties/header" }
+      }
+    }
+
   , "BlockNo":
     { "type": "integer"
     , "description": "A block number, the i-th block to be minted is number i."
@@ -2063,6 +2189,30 @@
       ]
     }
 
+  , "CostModels":
+    { "type": "object"
+    , "additionalProperties": { "$ref": "#/definition/CostModel" }
+    , "propertyNames": { "enum": [ "plutus:v1" ] }
+    , "examples":
+      [ { "plutus:v1":
+          { "k": 14
+          , "a": 123
+          }
+        }
+      ]
+    }
+
+  , "CostModel":
+    { "type": "object"
+    , "additionalProperties": { "type": "integer" }
+    }
+
+  , "DatumHash":
+    { "type": "string"
+    , "contentEncoding": "base16"
+    , "pattern": "^[0-9a-f]$"
+    }
+
   , "DelegationsAndRewards":
     { "type": "object"
     , "additionalProperties": false
@@ -2118,6 +2268,16 @@
           , "ledgerEra": { "$ref": "#/definitions/Era" }
           }
         }
+      }
+    }
+
+  , "ExUnits":
+    { "type": "object"
+    , "additionalProperties": false
+    , "required": [ "memory", "steps" ]
+    , "properties":
+      { "memory": { "type": "integer" }
+      , "steps": { "type": "integer" }
       }
     }
 
@@ -2505,6 +2665,16 @@
       ]
     }
 
+  , "Prices":
+    { "type": "object"
+    , "additionalProperties": false
+    , "required": [ "memory", "steps" ]
+    , "properties":
+      { "memory": { "$ref": "#/definitions/Lovelace" }
+      , "steps": { "$ref": "#/definitions/Lovelace" }
+      }
+    }
+
   , "ProtocolMagicId":
     { "type": "integer"
     , "examples":
@@ -2569,6 +2739,67 @@
       , "protocolVersion":
         { "oneOf":
           [ { "$ref": "#/definitions/ProtocolVersion" }
+          , { "type": "null", "title": "null" }
+          ]
+        }
+      }
+    }
+
+  , "ProtocolParameters[Alonzo]":
+    { "type": "object"
+    , "additionalProperties": false
+    , "properties":
+      { "minFeeCoefficient": { "$ref": "#/definitions/NullableInteger" }
+      , "minFeeConstant": { "$ref": "#/definitions/NullableInteger" }
+      , "maxBlockBodySize": { "$ref": "#/definitions/NullableInteger" }
+      , "maxBlockHeaderSize": { "$ref": "#/definitions/NullableInteger" }
+      , "maxTxSize": { "$ref": "#/definitions/NullableInteger" }
+      , "stakeKeyDeposit": { "$ref": "#/definitions/NullableInteger" }
+      , "poolDeposit": { "$ref": "#/definitions/NullableInteger" }
+      , "poolRetirementEpochBound": { "$ref": "#/definitions/NullableInteger" }
+      , "desiredNumberOfPools": { "$ref": "#/definitions/NullableInteger" }
+      , "poolInfluence": { "$ref": "#/definitions/NullableRatio" }
+      , "monetaryExpansion": { "$ref": "#/definitions/NullableRatio" }
+      , "treasuryExpansion": { "$ref": "#/definitions/NullableRatio" }
+      , "decentralizationParameter": { "$ref": "#/definitions/NullableRatio" }
+      , "minPoolCost": { "$ref": "#/definitions/NullableInteger" }
+      , "lovelacePerUtxoWord": { "$ref": "#/definitions/NullableInteger" }
+      , "maxValueSize": { "$ref": "#/definitions/NullableInteger" }
+      , "collateralPercentage": { "$ref": "#/definitions/NullableInteger" }
+      , "maxCollateralInputs": { "$ref": "#/definitions/NullableInteger" }
+      , "extraEntropy":
+        { "oneOf":
+          [ { "$ref": "#/definitions/Nonce" }
+          , { "type": "null", "title": "null" }
+          ]
+        }
+      , "protocolVersion":
+        { "oneOf":
+          [ { "$ref": "#/definitions/ProtocolVersion" }
+          , { "type": "null", "title": "null" }
+          ]
+        }
+      , "costModels":
+        { "oneOf":
+          [ { "$ref": "#/definitions/CostModels" }
+          , { "type": "null", "title": "null" }
+          ]
+        }
+      , "prices":
+        { "oneOf":
+          [ { "$ref": "#/definitions/Prices" }
+          , { "type": "null", "title": "null" }
+          ]
+        }
+      , "maxExecutionUnitsPerTransaction":
+        { "oneOf":
+          [ { "$ref": "#/definitions/ExUnits" }
+          , { "type": "null", "title": "null" }
+          ]
+        }
+      , "maxExecutionUnitsPerBlock":
+        { "oneOf":
+          [ { "$ref": "#/definitions/ExUnits" }
           , { "type": "null", "title": "null" }
           ]
         }
@@ -3148,6 +3379,7 @@
           { "oneOf":
               [ { "$ref": "#/definitions/TxOut" }
               , { "$ref": "#/definitions/TxOut[Mary]" }
+              , { "$ref": "#/definitions/TxOut[Alonzo]" }
               ]
           }
         }
@@ -3167,6 +3399,7 @@
           { "oneOf":
               [ { "$ref": "#/definitions/TxOut" }
               , { "$ref": "#/definitions/TxOut[Mary]" }
+              , { "$ref": "#/definitions/TxOut[Alonzo]" }
               ]
           }
         }
@@ -3534,6 +3767,17 @@
       }
     }
 
+  , "TxOut[Alonzo]":
+    { "type": "object"
+    , "additionalProperties": false
+    , "required": [ "address", "value" ]
+    , "properties":
+      { "address": { "$ref": "#/definitions/Address" }
+      , "value": { "$ref": "#/definitions/Value" }
+      , "datum": { "$ref": "#/definitions/DatumHash" }
+      }
+    }
+
   , "TxValidationError":
     { "oneOf":
       [ { "type": "string"
@@ -3703,6 +3947,23 @@
           , "proposal":
             { "type": "object"
             , "additionalProperties": { "$ref": "#/definitions/ProtocolParameters[Shelley]" }
+            }
+          }
+        }
+      ]
+    }
+
+  , "Update[Alonzo]":
+    { "oneOf":
+      [ { "type": "null", "title": "null" }
+      , { "type": "object"
+        , "title": "proposal"
+        , "required": ["proposal", "epoch"]
+        , "properties":
+          { "epoch": { "$ref": "#/definitions/Epoch" }
+          , "proposal":
+            { "type": "object"
+            , "additionalProperties": { "$ref": "#/definitions/ProtocolParameters[Alonzo]" }
             }
           }
         }

--- a/docs/static/ogmios.wsp.json
+++ b/docs/static/ogmios.wsp.json
@@ -3118,6 +3118,18 @@
         , { "$ref": "#/definitions/SubmitTxError[nonGenesisVoters]" }
         , { "$ref": "#/definitions/SubmitTxError[updateWrongEpoch]" }
         , { "$ref": "#/definitions/SubmitTxError[protocolVersionCannotFollow]" }
+        , { "$ref": "#/definitions/SubmitTxError[unredeemableScripts]" }
+        , { "$ref": "#/definitions/SubmitTxError[datumsMismatch]" }
+        , { "$ref": "#/definitions/SubmitTxError[extraDataMismatch]" }
+        , { "$ref": "#/definitions/SubmitTxError[missingRequiredSignatures]" }
+        , { "$ref": "#/definitions/SubmitTxError[collateralTooSmall]" }
+        , { "$ref": "#/definitions/SubmitTxError[collateralIsScript]" }
+        , { "$ref": "#/definitions/SubmitTxError[collateralHasNonAdaAssets]" }
+        , { "$ref": "#/definitions/SubmitTxError[tooManyCollateralInputs]" }
+        , { "$ref": "#/definitions/SubmitTxError[executionUnitsTooLarge]" }
+        , { "$ref": "#/definitions/SubmitTxError[outsideForecast]" }
+        , { "$ref": "#/definitions/SubmitTxError[validationTagMismatch]" }
+        , { "$ref": "#/definitions/SubmitTxError[collectErrors]" }
         ]
       }
     }
@@ -3694,6 +3706,141 @@
     , "required": [ "protocolVersionCannotFollow" ]
     , "properties":
       { "protocolVersionCannotFollow": { "$ref": "#/definitions/ProtocolVersion" }
+      }
+    }
+
+  , "SubmitTxError[unredeemableScripts]":
+    { "type": "object"
+    , "title": "unredeemableScripts"
+    , "additionalProperties": false
+    , "required": [ "unredeemableScripts" ]
+    , "properties":
+      { "unredeemableScripts":
+        { "type": "array"
+        }
+      }
+    }
+
+  , "SubmitTxError[datumsMismatch]":
+    { "type": "object"
+    , "title": "datumsMismatch"
+    , "additionalProperties": false
+    , "required": [ "datumsMismatch" ]
+    , "properties":
+      { "datumsMismatch":
+        { "type": "object"
+        }
+      }
+    }
+
+  , "SubmitTxError[extraDataMismatch]":
+    { "type": "object"
+    , "title": "extraDataMismatch"
+    , "additionalProperties": false
+    , "required": [ "extraDataMismatch" ]
+    , "properties":
+      { "extraDataMismatch":
+        { "type": "object"
+        }
+      }
+    }
+
+  , "SubmitTxError[missingRequiredSignatures]":
+    { "type": "object"
+    , "title": "missingRequiredSignatures"
+    , "additionalProperties": false
+    , "required": [ "missingRequiredSignatures" ]
+    , "properties":
+      { "missingRequiredSignatures":
+        { "type": "array"
+        }
+      }
+    }
+
+  , "SubmitTxError[collateralTooSmall]":
+    { "type": "object"
+    , "title": "collateralTooSmall"
+    , "additionalProperties": false
+    , "required": [ "collateralTooSmall" ]
+    , "properties":
+      { "collateralTooSmall":
+        { "type": "object"
+        }
+      }
+    }
+
+  , "SubmitTxError[collateralIsScript]":
+    { "type": "object"
+    , "title": "collateralIsScript"
+    , "additionalProperties": false
+    , "required": [ "collateralIsScript" ]
+    , "properties":
+      { "collateralIsScript":
+        { "type": "object"
+        }
+      }
+    }
+
+  , "SubmitTxError[collateralHasNonAdaAssets]":
+    { "type": "object"
+    , "title": "collateralHasNonAdaAssets"
+    , "additionalProperties": false
+    , "required": [ "collateralHasNonAdaAssets" ]
+    , "properties":
+      { "collateralHasNonAdaAssets":
+          { "type": "object"
+          }
+      }
+    }
+
+  , "SubmitTxError[tooManyCollateralInputs]":
+    { "type": "object"
+    , "title": "tooManyCollateralInputs"
+    , "additionalProperties": false
+    , "required": [ "tooManyCollateralInputs" ]
+    , "properties":
+      { "tooManyCollateralInputs":
+        { "type": "object"
+        }
+      }
+    }
+
+  , "SubmitTxError[executionUnitsTooLarge]":
+    { "type": "object"
+    , "title": "executionUnitsTooLarge"
+    , "additionalProperties": false
+    , "required": [ "executionUnitsTooLarge" ]
+    , "properties":
+      { "executionUnitsTooLarge":
+        { "type": "object"
+        }
+      }
+    }
+
+  , "SubmitTxError[outsideForecast]":
+    { "type": "object"
+    , "title": "outsideForecast"
+    , "additionalProperties": false
+    , "required": [ "outsideForecast" ]
+    , "properties":
+      { "outsideForecast": { "$ref": "#/definitions/SlotNo" }
+      }
+    }
+
+  , "SubmitTxError[validationTagMismatch]":
+    { "type": "string"
+    , "enum": [ "validationTagMismatch" ]
+    }
+
+  , "SubmitTxError[collectErrors]":
+    { "type": "object"
+    , "title": "collectErrors"
+    , "additionalProperties": false
+    , "required": [ "collectErrors" ]
+    , "properties":
+      { "collectErrors":
+        { "type": "array"
+        }
       }
     }
 

--- a/server/modules/hspec-json-schema/CHANGELOG.md
+++ b/server/modules/hspec-json-schema/CHANGELOG.md
@@ -12,7 +12,8 @@
 
 ### Removed
 
-ø
+- The errors no longer spit back the full schema, which turned out to be needlessly verbose (and unhelpful) for large schemas. The 'missing required property' error has also been removed when the
+  found and required keys are identical. This happen when using `oneOf` but failing to match the schema and it only creates more noise in the error output.
 
 ## [1.0.0] -- 2020-10-23
 

--- a/server/modules/hspec-json-schema/CHANGELOG.md
+++ b/server/modules/hspec-json-schema/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## edge / unreleased
+
+### Added
+
+ø
+
+### Changed
+
+- The `SchemaRef` references are now resolved outside of the property, to avoid unnecessary file-system accesses and speed up the test execution (~40%). Instead, the schema and resolved reference have to be fetched prior to calling `prop_validateToJSON` using `unsafeReadSchemaRef`.
+
+### Removed
+
+ø
+
 ## [1.0.0] -- 2020-10-23
 
 ### Added

--- a/server/modules/hspec-json-schema/src/Test/Hspec/Json/Schema.hs
+++ b/server/modules/hspec-json-schema/src/Test/Hspec/Json/Schema.hs
@@ -233,61 +233,59 @@ prettyRefInvalid = \case
         s "could not resolve pointer:" <+> s (show err)
     RefLoop ref _ _ ->
         s "could not resolve reference (looping) at:" <+> t ref
-    RefInvalid _ schema errs ->
-        let
-            n = NE.length errs
-        in
-            vsep
-            ( [ s "Schema: "
-              , s (BL8.unpack $ Json.encodePretty schema) <> linebreak
-              , s "Found" <+> int n <+> s "validation error(s)!" <> linebreak
-              ]
-              ++
-              punctuate hardline (prettyValidatorFailure <$> toList errs)
-            )
+    RefInvalid _ _schema errs ->
+        case prune (prettyValidatorFailure <$> toList errs) of
+            [] -> mempty
+            failures -> vsep failures
 
 prettyRequiredInvalid
     :: RequiredInvalid
     -> Doc
-prettyRequiredInvalid (RequiredInvalid (Required required) found _) =
-    vsep
-    [ s "missing required property"
-    , indent 4 $ group $ vsep
-        [ s "required: " <+> s (show $ toList required)
-        , s "found:    " <+> s (show $ toList found)
+prettyRequiredInvalid (RequiredInvalid (Required required) found _)
+    | required == found = mempty
+    | otherwise = vsep
+        [ s "missing required property"
+        , indent 4 $ group $ vsep
+            [ s "required: " <+> s (show $ toList required)
+            , s "found:    " <+> s (show $ toList found)
+            ]
         ]
-    ]
 
 prettyPropertiesRelatedInvalid
     :: PropertiesRelatedInvalid ValidatorFailure
     -> Doc
 prettyPropertiesRelatedInvalid = \case
     PropertiesRelatedInvalid props patterns additional ->
-        vsep
-        [ s "invalid properties in object"
-        , indent 4 $ group $ vsep $
-              [ prettyInvalidProperties (toList props) | not (null $ toList props) ]
-              ++
-              [ prettyInvalidPatterns (toList patterns) | not (null $ toList patterns) ]
-              ++
-              [ prettyInvalidAdditional additional | isJust additional ]
-        ]
+        let errs =
+                  [ prettyInvalidProperties (toList props) | not (null $ toList props) ]
+                  ++
+                  [ prettyInvalidPatterns (toList patterns) | not (null $ toList patterns) ]
+        in case prune errs of
+            [] -> mempty
+            failures -> vsep
+                [ s "invalid properties in object"
+                , indent 4 $ group $ vsep $ failures ++
+                    [ prettyInvalidAdditional additional | isJust additional ]
+                ]
   where
     prettyInvalidProperties props =
         let invalidProps = [ (prop, errs) | (prop, errs) <- props, not (null errs) ]
         in group $ vsep $ prettyInvalidProperty <$> invalidProps
 
     prettyInvalidProperty (prop, [err]) =
-        label <+> prettyValidatorFailure err
+        case prune [prettyValidatorFailure err] of
+            [failure] -> label <+> failure
+            _ -> mempty
       where
         label = s "invalid property" <+> squotes (t prop) <> s ":"
+
     prettyInvalidProperty (prop, errs) =
-        vsep
-        ( s "invalid property" <+> squotes (t prop)
-        : if null errs
-          then mempty
-          else [indent 4 (group $ vsep $ prettyValidatorFailure <$> errs)]
-        )
+        case prune (prettyValidatorFailure <$> errs) of
+            [] -> mempty
+            failures  -> vsep
+                ( s "invalid property" <+> squotes (t prop)
+                : [indent 4 (group $ vsep failures)]
+                )
 
     prettyInvalidPatterns patterns =
         group $ vsep $ prettyInvalidPattern <$> patterns
@@ -297,12 +295,12 @@ prettyPropertiesRelatedInvalid = \case
       where
         label = s "invalid regular expression /" <> t regex <> s "/ in" <+> t key <> s ":"
     prettyInvalidPattern ((Regex regex, Key key), errs) =
-        vsep
-        ( s "invalid regular expression /" <> t regex <> s "/ in" <+> t key <> s ":"
-        : if null errs
-          then mempty
-          else [indent 4 (group $ vsep $ prettyValidatorFailure <$> errs)]
-        )
+        case prune (prettyValidatorFailure <$> errs) of
+            [] -> mempty
+            failures -> vsep
+                ( s "invalid regular expression /" <> t regex <> s "/ in" <+> t key <> s ":"
+                : [indent 4 (group $ vsep failures)]
+                )
 
     prettyInvalidAdditional = \case
         Nothing -> mempty
@@ -323,15 +321,19 @@ prettyItemsInvalid
     -> Doc
 prettyItemsInvalid = \case
     ItemsObjectInvalid items ->
-        vsep
-        [ s "invalid items in object:"
-        , indent 4 (prettyIndexedList items)
-        ]
+        case prune [prettyIndexedList items] of
+            [failure] -> vsep
+                [ s "invalid items in object:"
+                , indent 4 failure
+                ]
+            _ -> mempty
     ItemsArrayInvalid items ->
-        vsep
-        [ s "invalid items in array:"
-        , indent 4 (prettyIndexedList items)
-        ]
+        case prune [prettyIndexedList items] of
+            [failure] -> vsep
+                [ s "invalid items in array:"
+                , indent 4 failure
+                ]
+            _ -> mempty
 
 prettyAdditionalItemsInvalid
     :: AdditionalItemsInvalid ValidatorFailure
@@ -340,10 +342,12 @@ prettyAdditionalItemsInvalid = \case
     AdditionalItemsBoolInvalid ixs ->
         s "unexpected additional item(s) at position(s):" <+> s (prettyIxs ixs)
     AdditionalItemsObjectInvalid items ->
-        vsep
-        [ s "invalid additional item(s):"
-        , indent 4 (prettyIndexedList items)
-        ]
+        case prune [prettyIndexedList items] of
+            [failure] -> vsep
+                [ s "invalid additional item(s):"
+                , indent 4 failure
+                ]
+            _ -> mempty
   where
     prettyIxs = show . toList . fmap (_unIndex . fst)
 
@@ -352,20 +356,24 @@ prettyAllOfInvalid
     -> Doc
 prettyAllOfInvalid = \case
     AllOfInvalid items ->
-        vsep
-        [ s "failed to validate all given schemas:"
-        , indent 4 (prettyIndexedList items)
-        ]
+        case prune [prettyIndexedList items] of
+            [failure] -> vsep
+                [ s "failed to validate all given schemas:"
+                , indent 4 failure
+                ]
+            _ -> mempty
 
 prettyAnyOfInvalid
     :: AnyOfInvalid ValidatorFailure
     -> Doc
 prettyAnyOfInvalid = \case
     AnyOfInvalid items ->
-        vsep
-        [ s "failed to validate any of given schemas:"
-        , indent 4 (prettyIndexedList items)
-        ]
+        case prune [prettyIndexedList items] of
+            [failure] -> vsep
+                [ s "failed to validate any of given schemas:"
+                , indent 4 failure
+                ]
+            _ -> mempty
 
 prettyOneOfInvalid
     :: OneOfInvalid ValidatorFailure
@@ -378,10 +386,12 @@ prettyOneOfInvalid = \case
         <+>
         s "matching schemas."
     NoSuccesses items _ ->
-        vsep
-        [ s "failed to validate one of given schemas:"
-        , indent 4 (prettyIndexedList items)
-        ]
+        case prune [prettyIndexedList items] of
+            [failure] -> vsep
+                [ s "failed to validate one of given schemas:"
+                , indent 4 failure
+                ]
+            _ -> mempty
 
 prettyTypeValidator
     :: TypeValidator
@@ -406,19 +416,28 @@ prettyIndexedList
     :: NonEmpty (Index, NonEmpty ValidatorFailure)
     -> Doc
 prettyIndexedList items =
-    group $ vsep $ prettyInvalidItem <$> toList items
+    case prune (prettyInvalidItem <$> toList items) of
+        [] -> mempty
+        failures -> group $ vsep failures
   where
     prettyInvalidItem (Index ix, err :| []) =
-        brackets (int ix) <+> prettyValidatorFailure err
+        case prune [prettyValidatorFailure err] of
+            [failure] -> brackets (int ix) <+> failure
+            _ -> mempty
     prettyInvalidItem (Index ix, errs) =
-        vsep
-        [ brackets (int ix)
-        , indent 4 (group $ vsep $ prettyValidatorFailure <$> toList errs)
-        ]
+        case prune (prettyValidatorFailure <$> toList errs) of
+            [] -> mempty
+            failures -> vsep
+                [ brackets (int ix)
+                , indent 4 (group $ vsep failures)
+                ]
 
 --
 -- Helpers
 --
+
+prune :: [Doc] -> [Doc]
+prune = filter (\x -> show x /= show empty)
 
 -- Like 'either', but fail in IO on 'Left'.
 unsafeEither :: Show e => Either e a -> IO a

--- a/server/ogmios.cabal
+++ b/server/ogmios.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c743cd494275c4f71acae05bb27199ed9b16dedb9679a62a25fb0fcf21162343
+-- hash: e35d7f4a03f6076120f2e477d63caeb6b7493261b7f8fe91f70477e29d4a3869
 
 name:           ogmios
 version:        3.2.0
@@ -20,13 +20,19 @@ license:        MPL-2.0
 license-file:   LICENSE
 build-type:     Simple
 extra-source-files:
-    static/assets/logo.png
-    static/assets/favicon.ico
+    LICENSE
+    README.md
+    CHANGELOG.md
     static/dashboard.html
     static/dashboard.js
     static/tests.html
     static/tests/chain-sync.js
     static/tests/state-query.js
+    static/assets/favicon.ico
+    static/assets/logo.png
+data-files:
+    test/golden/QueryResponse-utxo_1.json
+    test/golden/SubmitTxResponse_1.json
 
 source-repository head
   type: git

--- a/server/ogmios.cabal
+++ b/server/ogmios.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3bb7c87b75c0d0934e3dc62e7df2aa7ad57356645b936c9b47e3e6031ce544dc
+-- hash: c743cd494275c4f71acae05bb27199ed9b16dedb9679a62a25fb0fcf21162343
 
 name:           ogmios
 version:        3.2.0
@@ -280,6 +280,7 @@ test-suite unit
     , aeson
     , base >=4.7 && <5
     , cardano-client
+    , cardano-ledger-alonzo
     , cardano-ledger-core
     , cardano-slotting
     , generic-arbitrary

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -12,13 +12,15 @@ synopsis:            A JSON-WSP WebSocket client for cardano-node
 category:            Web
 
 extra-source-files:
-- static/assets/logo.png
-- static/assets/favicon.ico
-- static/dashboard.html
-- static/dashboard.js
-- static/tests.html
-- static/tests/chain-sync.js
-- static/tests/state-query.js
+- LICENSE
+- README.md
+- CHANGELOG.md
+- static/*
+- static/tests/*
+- static/assets/*
+
+data-files:
+- test/golden/*
 
 dependencies:
 - base >= 4.7 && < 5

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -122,6 +122,7 @@ tests:
     dependencies:
     - aeson
     - cardano-client
+    - cardano-ledger-alonzo
     - cardano-ledger-core
     - cardano-slotting
     - generic-arbitrary

--- a/server/src/Ogmios/Data/Json/Allegra.hs
+++ b/server/src/Ogmios/Data/Json/Allegra.hs
@@ -289,7 +289,7 @@ encodeWitnessSet
     -> Json
 encodeWitnessSet x = encodeObject
     [ ( "signatures"
-      , encodeFoldable Shelley.encodeWitVKey (Sh.addrWits x)
+      , Shelley.encodeWitVKeys (Sh.addrWits x)
       )
     , ( "scripts"
       , encodeMap Shelley.stringifyScriptHash encodeScript (Sh.scriptWits x)

--- a/server/src/Ogmios/Data/Json/Alonzo.hs
+++ b/server/src/Ogmios/Data/Json/Alonzo.hs
@@ -61,7 +61,7 @@ encodeAlonzoPredFail
 encodeAlonzoPredFail = \case
     Al.UnRedeemableScripts scripts ->
         encodeObject
-            [ ( "unreemableScripts"
+            [ ( "unredeemableScripts"
               , encodeFoldable (encode2Tuple encodeScriptPurpose Shelley.encodeScriptHash) scripts
               )
             ]

--- a/server/src/Ogmios/Data/Json/Alonzo.hs
+++ b/server/src/Ogmios/Data/Json/Alonzo.hs
@@ -374,7 +374,7 @@ encodeTxBody x = encodeObject
     [ ( "inputs"
       , encodeFoldable Shelley.encodeTxIn (Al.inputs x)
       )
-    , ( "collateral"
+    , ( "collaterals"
       , encodeFoldable Shelley.encodeTxIn (Al.collateral x)
       )
     , ( "outputs"

--- a/server/src/Ogmios/Data/Json/Alonzo.hs
+++ b/server/src/Ogmios/Data/Json/Alonzo.hs
@@ -618,7 +618,7 @@ encodeWitnessSet
     -> Json
 encodeWitnessSet x = encodeObject
     [ ( "signatures"
-      , encodeFoldable Shelley.encodeWitVKey (Al.txwitsVKey x)
+      , Shelley.encodeWitVKeys (Al.txwitsVKey x)
       )
     , ( "scripts"
       , encodeMap Shelley.stringifyScriptHash encodeScript (Al.txscripts x)

--- a/server/src/Ogmios/Data/Json/Alonzo.hs
+++ b/server/src/Ogmios/Data/Json/Alonzo.hs
@@ -348,14 +348,10 @@ encodeTx mode x = encodeObjectWithMode mode
     , ( "body"
       , encodeTxBody (Al.body x)
       )
-    , ( "metadata", encodeObject
-        [ ( "hash"
-          , encodeStrictMaybe Shelley.encodeAuxiliaryDataHash (adHash (Al.body x))
-          )
-        , ( "body"
-          , encodeStrictMaybe encodeAuxiliaryData (Al.auxiliaryData x)
-          )
-        ]
+    , ( "metadata"
+      , (,) <$> fmap (("hash",) . Shelley.encodeAuxiliaryDataHash) (adHash (Al.body x))
+            <*> fmap (("body",) . encodeAuxiliaryData) (Al.auxiliaryData x)
+        & encodeStrictMaybe (\(a, b) -> encodeObject [a,b])
       )
     ]
     [ ( "witness"

--- a/server/src/Ogmios/Data/Json/Byron.hs
+++ b/server/src/Ogmios/Data/Json/Byron.hs
@@ -186,6 +186,13 @@ encodeTxIn (By.TxInUtxo txid ix) = encodeObject
       )
     ]
 
+encodeValue
+    :: By.Lovelace
+    -> Json
+encodeValue coins = encodeObject
+    [ ( "coins", encodeLovelace coins )
+    ]
+
 encodeTxOut
     :: By.TxOut
     -> Json
@@ -194,7 +201,7 @@ encodeTxOut x = encodeObject
       , encodeAddress (By.txOutAddress x)
       )
     , ( "value"
-      , encodeLovelace (By.txOutValue x)
+      , encodeValue (By.txOutValue x)
       )
     ]
 

--- a/server/src/Ogmios/Data/Json/Mary.hs
+++ b/server/src/Ogmios/Data/Json/Mary.hs
@@ -299,7 +299,7 @@ encodeWitnessSet
     -> Json
 encodeWitnessSet x = encodeObject
     [ ( "signatures"
-      , encodeFoldable Shelley.encodeWitVKey (Sh.addrWits x)
+      , Shelley.encodeWitVKeys (Sh.addrWits x)
       )
     , ( "scripts"
       , encodeMap Shelley.stringifyScriptHash Allegra.encodeScript (Sh.scriptWits x)

--- a/server/src/Ogmios/Data/Json/Prelude.hs
+++ b/server/src/Ogmios/Data/Json/Prelude.hs
@@ -66,6 +66,7 @@ module Ogmios.Data.Json.Prelude
     , encodeAnnotated
     , encodeIdentity
     , encodeFoldable
+    , encodeFoldable'
     , encodeList
     , encodeMap
     , encodeMaybe
@@ -376,6 +377,16 @@ encodeFoldable encodeElem =
 {-# SPECIALIZE encodeFoldable :: (a -> Json) -> Set a -> Json #-}
 {-# SPECIALIZE encodeFoldable :: (a -> Json) -> StrictSeq a -> Json #-}
 {-# INLINABLE encodeFoldable #-}
+
+encodeFoldable' :: Foldable f => (a -> Text) -> (a -> Json) -> f a -> Json
+encodeFoldable' encodeKey encodeValue =
+    Json.pairs . foldr (\a -> (<>) (Json.pair (encodeKey a) (encodeValue a))) mempty
+{-# SPECIALIZE encodeFoldable' :: (a -> Text) -> (a -> Json) -> [a] -> Json #-}
+{-# SPECIALIZE encodeFoldable' :: (a -> Text) -> (a -> Json) -> NonEmpty a -> Json #-}
+{-# SPECIALIZE encodeFoldable' :: (a -> Text) -> (a -> Json) -> Vector a -> Json #-}
+{-# SPECIALIZE encodeFoldable' :: (a -> Text) -> (a -> Json) -> Set a -> Json #-}
+{-# SPECIALIZE encodeFoldable' :: (a -> Text) -> (a -> Json) -> StrictSeq a -> Json #-}
+{-# INLINABLE encodeFoldable' #-}
 
 encodeList :: (a -> Json) -> [a] -> Json
 encodeList =

--- a/server/src/Ogmios/Data/Json/Shelley.hs
+++ b/server/src/Ogmios/Data/Json/Shelley.hs
@@ -894,7 +894,7 @@ encodeTx mode x = encodeObjectWithMode mode
       )
     , ( "metadata"
       , (,) <$> fmap (("hash",) . encodeAuxiliaryDataHash) (Sh._mdHash (Sh.body x))
-            <*> fmap (("body",) . encodeMetadata ) (Sh.auxiliaryData x)
+            <*> fmap (("body",) . encodeMetadata) (Sh.auxiliaryData x)
         & encodeStrictMaybe (\(a, b) -> encodeObject [a,b])
       )
     ]

--- a/server/src/Ogmios/Data/Json/Shelley.hs
+++ b/server/src/Ogmios/Data/Json/Shelley.hs
@@ -954,12 +954,12 @@ encodeTxOut
     :: (ShelleyBased era, Core.Value era ~ Coin)
     => Sh.TxOut era
     -> Json
-encodeTxOut (Sh.TxOut addr coin) = encodeObject
+encodeTxOut (Sh.TxOut addr value) = encodeObject
     [ ( "address"
       , encodeAddress addr
       )
     , ( "value"
-      , encodeCoin coin
+      , encodeValue value
       )
     ]
 
@@ -1163,6 +1163,13 @@ encodeUtxowFailure encodeUtxoFailure_ = \case
         encodeText "invalidMetadata"
     Sh.UtxoFailure e ->
         encodeUtxoFailure_ e
+
+encodeValue
+    :: Coin
+    -> Json
+encodeValue coin = encodeObject
+    [ ( "coins", encodeCoin coin )
+    ]
 
 encodeVerKeyDSign
     :: CC.DSIGNAlgorithm alg

--- a/server/src/Ogmios/Data/Json/Shelley.hs
+++ b/server/src/Ogmios/Data/Json/Shelley.hs
@@ -1213,7 +1213,7 @@ encodeWitnessSet
     -> Json
 encodeWitnessSet x = encodeObject
     [ ( "signatures"
-      , encodeFoldable encodeWitVKey (Sh.addrWits x)
+      , encodeWitVKeys (Sh.addrWits x)
       )
     , ( "scripts"
       , encodeMap stringifyScriptHash encodeScript (Sh.scriptWits x)
@@ -1229,12 +1229,13 @@ encodeWitHashes
 encodeWitHashes =
     encodeFoldable encodeKeyHash . Sh.unWitHashes
 
-encodeWitVKey
+encodeWitVKeys
     :: Crypto crypto
-    => Sh.WitVKey Sh.Witness crypto
+    => Set (Sh.WitVKey 'Sh.Witness crypto)
     -> Json
-encodeWitVKey (Sh.WitVKey key sig) =
-    encodeObject [(stringifyVKey  key, encodeSignedDSIGN sig)]
+encodeWitVKeys = encodeFoldable'
+    (\(Sh.WitVKey key _) -> stringifyVKey key)
+    (\(Sh.WitVKey _ sig) -> encodeSignedDSIGN sig)
 
 --
 -- Conversion To Text

--- a/server/test/golden/QueryResponse-utxo_1.json
+++ b/server/test/golden/QueryResponse-utxo_1.json
@@ -1,0 +1,33 @@
+{
+  "reflection": null,
+  "methodname": "Query",
+  "result": [
+    [
+      {
+        "index": 362,
+        "txId": "0268be9dbd0446eaa217e1dec8f399249305e551d7fc1437dd84521f74aa621c"
+      },
+      {
+        "value": {
+          "coins": 856
+        },
+        "address": "addr1gyxefct5wvh0n2h88uu44dz9q7l6nq7k2q3uzx54ruxr9eyx3yucz7u8y5n4uwjm"
+      }
+    ],
+    [
+      {
+        "index": 365,
+        "txId": "0268be9dbd0446eaa217e1dec8f399249305e551d7fc1437dd84521f74aa621c"
+      },
+      {
+        "value": {
+          "coins": 736
+        },
+        "address": "2RhQhCGqYPDqAydwiQvfu853oqB2r5DQbXRgAF6U8TgHTNFQDmuPdERgB9J3cvQJT2dSpPxJZjRZ1KRVBLcgEJcTg95qtoCceN7Soy5GKbrzzD"
+      }
+    ]
+  ],
+  "version": "1.0",
+  "servicename": "ogmios",
+  "type": "jsonwsp/response"
+}

--- a/server/test/golden/SubmitTxResponse_1.json
+++ b/server/test/golden/SubmitTxResponse_1.json
@@ -1,0 +1,182 @@
+{
+  "version": "1.0",
+  "servicename": "ogmios",
+  "type": "jsonwsp/response",
+  "reflection": 14,
+  "methodname": "SubmitTx",
+  "result": {
+    "SubmitFail": [
+      {
+        "missingVkWitnesses": [
+          "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4",
+          "76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b8",
+          "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a",
+          "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54",
+          "e36cac9d067342ad1d24bbcff93669c0d19d1d5b5cc80df3a8227a9e"
+        ]
+      },
+      {
+        "delegateNotRegistered": "pool1y06yul5r58xhvfyqtf7k69k9ljjnz742rk5elsz73n0jveznsv7"
+      },
+      {
+        "extraDataMismatch": {
+          "provided": "fadd2180bd6b1cfa73a67e7892d878521ef69918995040fb8661647d321e0c55",
+          "inferredFromParameters": "fb3d635c7cb573d1b9e9bff4a64ab4f25190d29b6fd8db94c605a218a23fa9ad"
+        }
+      },
+      {
+        "delegateNotRegistered": "pool1x4p2evaxfkqv9yczycxk9sac0f6z4522h7z4a0r8xvypuxru6s8"
+      },
+      {
+        "unredeemableScripts": []
+      },
+      {
+        "collateralIsScript": [
+          [
+            {
+              "index": 996,
+              "txId": "0268be9dbd0446eaa217e1dec8f399249305e551d7fc1437dd84521f74aa621c"
+            },
+            {
+              "value": {
+                "coins": 36,
+                "assets": {
+                  "65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7.a6": 18,
+                  "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5": 60,
+                  "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54.410d": 28,
+                  "4b279a388de46bb4d33c4df64da357640be900b04625a43651b7b059.362c97a9401bca": 16,
+                  "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2.56c2f3fd5d9ec0": 62,
+                  "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541.2f676f": 29
+                }
+              },
+              "address": "EqGAuA8vHnP8zRHTpYAq6raRzvcMep1Vf4ceR7AvTzguQroTYtvNsjosfb3HSpMaKwMpd58c5YouBeH97ZkgaxxpSc9eP6aze8q6MMbhnae4XRVqSC5HYYA",
+              "datum": "95c3003a78585e0db8c9496f6deef4de0ff000994b8534cd66d4fe96bb21ddd3"
+            }
+          ],
+          [
+            {
+              "index": 780,
+              "txId": "3f3782871202b3e4e89ec4d17789d86b05cdca5efd81be573baf93403dc3b29a"
+            },
+            {
+              "value": {
+                "coins": 10,
+                "assets": {
+                  "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5.e17d": 13,
+                  "23f44e7e83a1cd7624805a7d6d16c5fca5317aaa1da99fc05e8cdf26.7d89b3e4ce": 7,
+                  "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e.bfb2ceae9f": 51
+                }
+              },
+              "address": "2RhQhCGqYPDopNqqXS5Fzj9PfApNbji2rL5bhEx1tt1uvptcnjyAWi1rLayYVbWVNuNxYVL8fDcV3JLmYxdCWr6Uq3pc3brxtwipbw4XfajvMy",
+              "datum": "ee155ace9c40292074cb6aff8c9ccdd273c81648ff1149ef36bcea6ebb8a3e25"
+            }
+          ],
+          [
+            {
+              "index": 142,
+              "txId": "4f539156bfbefc070a3b61cad3d1cedab3050e2b2a62f0ffe16a43eb0edc1ce8"
+            },
+            {
+              "value": {
+                "coins": 41,
+                "assets": {}
+              },
+              "address": "EqGAuA8vHnNfpApaiebYt44vKFkL5tku8Q9kTUWAqsCNryHMSBUygqMmRj9kwmjqwR2tiqwsxnetAPrnL9cq1k4sG9E7nAyFMtz5bK51xPH3t9KWfcPV5iC",
+              "datum": "2208e439244a1d0ef238352e3693098aba9de9dd0154f9056551636c8ed15dc1"
+            }
+          ],
+          [
+            {
+              "index": 94,
+              "txId": "ee155ace9c40292074cb6aff8c9ccdd273c81648ff1149ef36bcea6ebb8a3e25"
+            },
+            {
+              "value": {
+                "coins": 63,
+                "assets": {
+                  "4b279a388de46bb4d33c4df64da357640be900b04625a43651b7b059.b9c8aa09": 18
+                }
+              },
+              "address": "addr_test1qpmwvp7m9gcungkryasaysc6rp492rxry8meekxk4q4jnw8ve0a4ccvkw0cxfzjzeshcytype0p54mjpyarr36y60t6shunvvh",
+              "datum": null
+            }
+          ],
+          [
+            {
+              "index": 405,
+              "txId": "ee155ace9c40292074cb6aff8c9ccdd273c81648ff1149ef36bcea6ebb8a3e25"
+            },
+            {
+              "value": {
+                "coins": 26,
+                "assets": {
+                  "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5.44e9e45e": 23,
+                  "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541": 29,
+                  "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56.711159": 33,
+                  "23f44e7e83a1cd7624805a7d6d16c5fca5317aaa1da99fc05e8cdf26.035e91": 30,
+                  "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2.2b": 61,
+                  "76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b8.9bb5": 34,
+                  "e36cac9d067342ad1d24bbcff93669c0d19d1d5b5cc80df3a8227a9e.95e67bdf4c": 54
+                }
+              },
+              "address": "EqGAuA8vHnNsXFxDf3dg8dmi8RnxMcQFbjoGTuPWqzFd4Mcq1XG3pFb9HDs3RJxzNUJwzTvsWTCcFVRsKURJ9UZekr2tBFAVddTzGzuajjwm4t24darPjQo",
+              "datum": "873e4fe9e41e924911bba3ec53ff4782efc8c0f244fb75c879f8a4328d0142ca"
+            }
+          ],
+          [
+            {
+              "index": 222,
+              "txId": "f63498b4ae65be466e4a71878971b9c524458996450b0ff8262cddf3f0d99229"
+            },
+            {
+              "value": {
+                "coins": 44,
+                "assets": {}
+              },
+              "address": "addr_test1xrkvh76uvxt88ury3fpvctuz9jquhs62aeqjw33cazd84a2ty7dr3r0ydw6dx0zd7ex6x4myp05spvzxykjrv5dhkpvst0ffq5",
+              "datum": "ee155ace9c40292074cb6aff8c9ccdd273c81648ff1149ef36bcea6ebb8a3e25"
+            }
+          ],
+          [
+            {
+              "index": 116,
+              "txId": "fb3d635c7cb573d1b9e9bff4a64ab4f25190d29b6fd8db94c605a218a23fa9ad"
+            },
+            {
+              "value": {
+                "coins": 8,
+                "assets": {
+                  "e36cac9d067342ad1d24bbcff93669c0d19d1d5b5cc80df3a8227a9e.bff209994a35": 63,
+                  "76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b8.b9af": 26
+                }
+              },
+              "address": "EqGAuA8vHnP8AQMNFJ97QjNtHA6oE3zFySWHPsDWfLnJ13gFmAGwxfRYGkVNDoG8CNcgz4SFEBEQBcFDR2w6HRiZZ3Cp1CFUE71LzdtypEaZGGTW79UqHpK",
+              "datum": null
+            }
+          ],
+          [
+            {
+              "index": 805,
+              "txId": "fb3d635c7cb573d1b9e9bff4a64ab4f25190d29b6fd8db94c605a218a23fa9ad"
+            },
+            {
+              "value": {
+                "coins": 3,
+                "assets": {
+                  "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5.332847fb729b": 14,
+                  "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e": 30,
+                  "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541.bac6212bea": 9,
+                  "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2.6721c183": 50,
+                  "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54.34f4b5416209a0": 44,
+                  "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a.8adad7beb7dfa3": 28
+                }
+              },
+              "address": "addr_test1yz7s88u4da9nqte6km78cjavxdg22s85ftup4pyjr9xa9snkucrak233ex3vxfmp6fp35xr225xvxg0hnnvdd2pt9xuq2p3cud",
+              "datum": null
+            }
+          ]
+        ]
+      }
+    ]
+  }
+}

--- a/server/test/unit/Ogmios/Data/JsonSpec.hs
+++ b/server/test/unit/Ogmios/Data/JsonSpec.hs
@@ -387,7 +387,7 @@ instance Arbitrary (SubmitResult (HardForkApplyTxErr (CardanoEras StandardCrypto
         , (10, SubmitFail . ApplyTxErrShelley <$> reasonablySized arbitrary)
         , (10, SubmitFail . ApplyTxErrAllegra <$> reasonablySized arbitrary)
         , (10, SubmitFail . ApplyTxErrMary <$> reasonablySized arbitrary)
-        -- FIXME: (10, SubmitFail . ApplyTxErrAlonzo <$> reasonablySized arbitrary)
+        , (10, SubmitFail . ApplyTxErrAlonzo <$> reasonablySized arbitrary)
         ]
 
 instance Arbitrary (Acquire Block) where


### PR DESCRIPTION
- :round_pushpin: **Cover Alonzo[Block] in the JSON-WSP specification.**
    This does not yet cover the new errors coming from the transaction submission. So I don't expect the corresponding tests to pass, but the RequestNextResponse now should when enabling Alonzo generators.

- :round_pushpin: **Generate AlonzoBlock as part of the JSON test suite**
    Weirdly enough, I couldn't resort to a simple 'Arbitrary' this time, because it seems that the transactions within blocks are different from the transactions generated by the arbitrary instance. So, I had to fmap on the sequence of Tx using a newly introduced 'toTxSeq'. I don't know if the tests pass since I am running some heavy simulations on the side and my laptop will just die of exhaustion if I run the test ... I knew 16GB of RAM was not enough. Anyway, CI will tell.

- :round_pushpin: **Wrap up JSON-WSP definitions for Alonzo blocks. Tests now pass.**
  
- :round_pushpin: **Return vkey signatures as a map instead of a list of singletons.**
  
- :round_pushpin: **Make JSON tests a bit faster by reading schema from disk only once per test group.**
    Instead of once for every prop execution! From 80s to 55s. Not much, but that's good to take :).

- :round_pushpin: **Start documenting new Alonzo SubmitTx errors in JSON-WSP**
  
- :round_pushpin: **Wrap up JSON-WSP definitions for Alonzo types.**
  
- :round_pushpin: **Merge TxOut JSON definitions together**
    Instead of carrying around 3 definitions for TxOut in Shelley/Allegra, TxOut in Mary and TxOut in Alonzo. I've also changed the base definition of 'value' in Pre-Mary eras to be a singleton object with a single field 'coins', so that it's uniform / compatible with next eras. This is however yet-another-breaking change.

- :round_pushpin: **Add missing Alonzo generators for state-queries scenarios.**
  
- :round_pushpin: **Rework a bit error reporting from hspec-json-schema to be less noisy / more helpful**
    The Ogmios schema is more than 4000 lines long, with a lot of models and nested schemas, so spitting schemas back on stdout for each errors can get very verbose. It started from a good intention,but turns out to be quite useless in practice. In the end, having the failing JSON and the errors is more useful for debugging.

- :round_pushpin: **Make sure to also build modules' tests files in the continuous integration workflow**
    The tests aren't executed in CI (only the server tests are). Yet, we should still build them to make sure everything in the source at least compiles.

- :round_pushpin: **Add support for testing with Golden files + fix some tricky schema issues found by chance**
    Sometimes, it's hard to reproduce failing cases with tests and debugging can be quite hard. Now, one can add a golden JSON file (obtained from the hspec-json-schema error output) to be expicitely tested, like a pre-generated case. Currently versioning some of tricky cases which popped up sporadically while testing other things.

- :round_pushpin: **More CHANGELOG update related to Alonzo.**
  
- :round_pushpin: **Update clients/TypeScript**
    I ended up fixing a few things in the JSON schema which has been bothering me for a while. Since the next update will be a major upgrade, it makes sense to pack breaking changes into it. I've therefore tweaked the JSON-WSP specifications to void generating types with identical names, forcing the generating to distinguish them using indexes (e.g. TxTooLarge vs TxTooLarge1). This commit also adds new tx submission errors and fixes the Utxo type now merged into one.